### PR TITLE
Add MathJax support for LaTeX rendering

### DIFF
--- a/static/templates/template.html
+++ b/static/templates/template.html
@@ -21,6 +21,17 @@
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="alternate" type="application/atom+xml" title="{{site_name}}" href="/feed.xml">
     
+    <!-- MathJax for LaTeX rendering -->
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']],
+                displayMath: [['$$', '$$'], ['\\[', '\\]']]
+            }
+        };
+    </script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
     <!-- Umami Analytics -->
     <script defer src="https://cloud.umami.is/script.js" data-website-id="{{umami_website_id}}"></script>
     


### PR DESCRIPTION
## Summary
This PR adds MathJax integration to enable LaTeX mathematical notation rendering across the site.

## Changes
- Added MathJax 3 script from CDN (jsdelivr) to the base template
- Configured MathJax to support both inline (`$...$`, `\(...\)`) and display (`$$...$$`, `\[...\]`) math notation
- Placed configuration before the async script load to ensure proper initialization

## Implementation Details
- MathJax is loaded asynchronously to avoid blocking page rendering
- Configuration supports standard LaTeX delimiters for both inline and display math modes
- Uses the tex-mml-chtml processor for comprehensive math rendering support

https://claude.ai/code/session_01Ko8bmBv65QknbEjhxbpRgd