### PR TITLE
Redesign blog to v5 hybrid layout from design mockup

### DIFF
--- a/build.py
+++ b/build.py
@@ -2,7 +2,7 @@
 from config import SITE_NAME, BIO, HOSTNAME, UMAMI, NAVIGATION
 from pathlib import Path
 from datetime import datetime
-import shutil, re, html
+import shutil, re, html, math
 import markdown  # only external dependency
 
 
@@ -11,40 +11,47 @@ POSTS = ROOT / "posts"
 PAGES = ROOT / "pages"
 OUT = ROOT / "out"
 TEMPL = (ROOT / "static" / "templates" / "template.html").read_text(encoding="utf-8")
+
+
 def _nav_href(path):
     path = path.strip("/")
     return "/" if not path else f"/{path}.html"
 
-NAV_HTML = "<ul>" + "".join(
-    f'<li><a href="{_nav_href(n["path"])}">{n["title"]}</a></li>'
+
+NAV_HTML = "".join(
+    f'<a href="{_nav_href(n["path"])}">{n["title"]}</a>'
     for n in NAVIGATION
-) + "</ul>" if NAVIGATION else ""
+) if NAVIGATION else ""
+
+
+def _iso_date(dd_mm_yyyy):
+    parts = dd_mm_yyyy.split("-")
+    return f"{parts[2]}-{parts[1]}-{parts[0]}"
+
+
+def _read_time(text):
+    words = len(text.split())
+    minutes = max(1, math.ceil(words / 250))
+    return f"{minutes} min read"
 
 
 def process_external_links(html_content):
-    """Add target="_blank" and rel="noopener noreferrer" to external links"""
-    # Pattern to match <a href="..."> tags
     link_pattern = r'<a\s+href="([^"]+)"([^>]*)>'
-    
+
     def replace_link(match):
         href = match.group(1)
         other_attrs = match.group(2)
-        
-        # Check if it's an external link (starts with http:// or https://)
         if href.startswith(('http://', 'https://')):
-            # Add target="_blank" and rel="noopener noreferrer" if not already present
             if 'target="_blank"' not in other_attrs:
                 other_attrs += ' target="_blank"'
             if 'rel="noopener noreferrer"' not in other_attrs:
                 other_attrs += ' rel="noopener noreferrer"'
-        
         return f'<a href="{href}"{other_attrs}>'
-    
+
     return re.sub(link_pattern, replace_link, html_content)
 
 
 def render(markdown_text):
-    """convert md → html using python-markdown"""
     html_content = markdown.markdown(
         markdown_text,
         extensions=[
@@ -59,39 +66,23 @@ def render(markdown_text):
             }
         }
     )
-    
-    # Process external links to add target="_blank"
     return process_external_links(html_content)
 
 
-def apply_template(title, body_html, seo_image="", seo_description="", date="", main_heading=""):
+def apply_template(title, body_html, seo_image="", seo_description=""):
     return (TEMPL.replace("{{title}}", html.escape(title))
             .replace("{{content}}", body_html)
             .replace("{{year}}", str(datetime.now().year))
             .replace("{{site_name}}", SITE_NAME)
-            .replace("{{bio.name}}", BIO["name"])
-            .replace("{{bio.bio}}", BIO["bio"])
-            .replace("{{bio.image}}", BIO["image"])
-            .replace("{{bio.social.x.url}}", BIO["social"]["x"]["url"])
-            .replace("{{bio.social.x.icon}}", BIO["social"]["x"]["icon"])
-            .replace("{{bio.social.linkedin.url}}", BIO["social"]["linkedin"]["url"])
-            .replace("{{bio.social.linkedin.icon}}", BIO["social"]["linkedin"]["icon"])
-            .replace("{{bio.social.github.url}}", BIO["social"]["github"]["url"])
-            .replace("{{bio.social.github.icon}}", BIO["social"]["github"]["icon"])
-            .replace("{{bio.social.rss.url}}", BIO["social"]["rss"]["url"])
-            .replace("{{bio.social.rss.icon}}", BIO["social"]["rss"]["icon"])
             .replace("{{nav}}", NAV_HTML)
             .replace("{{seo_image}}", seo_image)
             .replace("{{seo_description}}", seo_description)
-            .replace("{{date}}", date)
-            .replace("{{main_heading}}", main_heading)
             .replace("{{umami_website_id}}", UMAMI["website_id"]))
 
 
 def build_post(md_path, is_page=False):
     raw = md_path.read_text(encoding="utf-8")
-    
-    # Parse frontmatter if it exists
+
     frontmatter = {}
     if raw.startswith("---"):
         _, frontmatter_text, content = raw.split("---", 2)
@@ -100,54 +91,80 @@ def build_post(md_path, is_page=False):
                 key, value = line.split(":", 1)
                 frontmatter[key.strip()] = value.strip().strip('"')
         raw = content.strip()
-    
+
     h1, _, body = raw.partition("\n")
     title = h1.lstrip("# ").strip() or md_path.stem
     html_body = render(body)
-    
-    # Get SEO data from frontmatter or use defaults
+
     seo_image = frontmatter.get("seo_image", "/static/images/profile.png")
     seo_description = frontmatter.get("seo_description", "")
-    
-    # Make SEO image URL absolute
+
     if seo_image and not seo_image.startswith(('http://', 'https://')):
         seo_image = HOSTNAME + seo_image
-    
+
     if is_page:
-        main_heading = f'<h1>{html.escape(title)}</h1>'
-        date = ""
+        content_html = f'<h1>{html.escape(title)}</h1>\n{html_body}'
     else:
-        date = frontmatter.get("date", "-".join(md_path.stem.split("-", 3)[:3]))
-        main_heading = f'<h1>{html.escape(title)}</h1>\n<time datetime="{date}" class="post-date">{date}</time>'
-    
-    return title, apply_template(title, html_body, seo_image=seo_image, seo_description=seo_description, date=date, main_heading=main_heading)
+        date_str = frontmatter.get("date", "-".join(md_path.stem.split("-", 3)[:3]))
+        iso_date = _iso_date(date_str)
+        read_time = _read_time(body)
+
+        parts = []
+        parts.append('<article>')
+        parts.append(f'<div class="post-meta"><span>{iso_date}</span><span>{read_time}</span></div>')
+        parts.append(f'<h1 class="post-title">{html.escape(title)}</h1>')
+        if seo_description:
+            parts.append(f'<p class="dek">{html.escape(seo_description)}</p>')
+        parts.append(html_body)
+        parts.append('</article>')
+        content_html = "\n".join(parts)
+
+    return title, apply_template(title, content_html, seo_image=seo_image, seo_description=seo_description)
+
+
+def _bio_html():
+    social_links = ""
+    for key, s in BIO["social"].items():
+        url = s["url"]
+        if url.startswith(('http://', 'https://')):
+            social_links += (
+                f'<a href="{url}" target="_blank" rel="noopener noreferrer">'
+                f'<img src="{s["icon"]}" alt="{key.capitalize()}"></a>'
+            )
+        else:
+            social_links += (
+                f'<a href="{url}">'
+                f'<img src="{s["icon"]}" alt="{key.capitalize()}"></a>'
+            )
+    return (
+        f'<div class="bio-inline">'
+        f'<img src="{BIO["image"]}" alt="{BIO["name"]}">'
+        f'<div class="body">'
+        f'<p>{BIO["bio"]}</p>'
+        f'<div class="social">{social_links}</div>'
+        f'</div></div>'
+    )
 
 
 def main():
-    # clean & recreate output dir
     if OUT.exists(): shutil.rmtree(OUT)
     OUT.mkdir()
 
-    # copy static directory
     static_dir = ROOT / "static"
     if static_dir.exists():
         shutil.copytree(static_dir, OUT / "static")
 
-    # copy standalone HTML pages to output root
     html_dir = ROOT / "html"
     if html_dir.exists():
         for f in html_dir.glob("*.html"):
             shutil.copy(f, OUT / f.name)
 
-    # Process pages
     pages = sorted(PAGES.glob("*.md"))
     for md in pages:
         title, full_html = build_post(md, is_page=True)
         slug = md.stem
-        fname = f"{slug}.html"
-        (OUT / fname).write_text(full_html, encoding="utf-8")
+        (OUT / f"{slug}.html").write_text(full_html, encoding="utf-8")
 
-    # collect posts, sorted by date (newest first)
     def post_date(md_path):
         parts = md_path.stem.split("-", 3)[:3]
         return datetime.strptime("-".join(parts), "%d-%m-%Y")
@@ -157,53 +174,41 @@ def main():
 
     for md in posts:
         title, full_html = build_post(md)
-        slug = md.stem.split("-", 3)[-1]  # after the date
+        slug = md.stem.split("-", 3)[-1]
         fname = f"{slug}.html"
         (OUT / fname).write_text(full_html, encoding="utf-8")
-        date = "-".join(md.stem.split("-", 3)[:3])
-        year = md.stem.split("-")[2]  # DD-MM-YYYY -> YYYY
+        date_str = "-".join(md.stem.split("-", 3)[:3])
+        iso_date = _iso_date(date_str)
+        year = md.stem.split("-")[2]
         posts_by_year.setdefault(year, []).append(
-            f"<li><a href='{fname}'>{title}</a> <small>{date}</small></li>")
+            f'<li><a href="{fname}">{title}</a>'
+            f'<time datetime="{iso_date}">{iso_date}</time></li>'
+        )
 
-    # Create index with posts grouped by year
-    index_content = []
-    index_content.append('<div class="main-content">')
-    index_content.append('<h1>Posts</h1>')
+    total_posts = sum(len(v) for v in posts_by_year.values())
+    index_parts = []
+    index_parts.append(_bio_html())
+    index_parts.append(
+        f'<h1 class="page-title">Writing <span class="count">{total_posts} posts</span></h1>'
+    )
     for year in sorted(posts_by_year, reverse=True):
-        index_content.append(f"<h2>{year}</h2>")
-        index_content.append("<ul>")
-        index_content.extend(posts_by_year[year])
-        index_content.append("</ul>")
-    index_content.append('</div>')
+        index_parts.append(f'<section class="year-block"><h2>{year}</h2><ul class="posts">')
+        index_parts.extend(posts_by_year[year])
+        index_parts.append('</ul></section>')
 
-    # Default SEO image for index page
     default_seo_image = HOSTNAME + "/static/images/profile.png"
-
-    index_html = apply_template(SITE_NAME, "\n".join(index_content), main_heading="", seo_image=default_seo_image)
+    index_html = apply_template(SITE_NAME, "\n".join(index_parts), seo_image=default_seo_image)
     (OUT / "index.html").write_text(index_html, encoding="utf-8")
 
-    # Generate sitemap.xml
-    sitemap_urls = []
-
-    # Index page
-    sitemap_urls.append({"loc": HOSTNAME + "/", "priority": "1.0"})
-
-    # Pages
+    # sitemap
+    sitemap_urls = [{"loc": HOSTNAME + "/", "priority": "1.0"}]
     for md in pages:
-        slug = md.stem
-        sitemap_urls.append({"loc": f"{HOSTNAME}/{slug}.html", "priority": "0.8"})
-
-    # Posts (newest first, already sorted)
+        sitemap_urls.append({"loc": f"{HOSTNAME}/{md.stem}.html", "priority": "0.8"})
     for md in posts:
         slug = md.stem.split("-", 3)[-1]
         parts = md.stem.split("-", 3)[:3]
-        # Convert DD-MM-YYYY to YYYY-MM-DD for sitemap lastmod
         lastmod = f"{parts[2]}-{parts[1]}-{parts[0]}"
-        sitemap_urls.append({
-            "loc": f"{HOSTNAME}/{slug}.html",
-            "lastmod": lastmod,
-            "priority": "0.6",
-        })
+        sitemap_urls.append({"loc": f"{HOSTNAME}/{slug}.html", "lastmod": lastmod, "priority": "0.6"})
 
     sitemap_xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
     sitemap_xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
@@ -217,12 +222,12 @@ def main():
     sitemap_xml += "</urlset>\n"
     (OUT / "sitemap.xml").write_text(sitemap_xml, encoding="utf-8")
 
-    # Generate Atom feed (feed.xml)
+    # atom feed
     feed_xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
     feed_xml += '<feed xmlns="http://www.w3.org/2005/Atom">\n'
     feed_xml += f"  <title>{html.escape(SITE_NAME)}</title>\n"
-    feed_xml += f"  <link href=\"{HOSTNAME}/\" />\n"
-    feed_xml += f"  <link href=\"{HOSTNAME}/feed.xml\" rel=\"self\" />\n"
+    feed_xml += f'  <link href="{HOSTNAME}/" />\n'
+    feed_xml += f'  <link href="{HOSTNAME}/feed.xml" rel="self" />\n'
     feed_xml += f"  <id>{HOSTNAME}/</id>\n"
     if posts:
         newest_parts = posts[0].stem.split("-", 3)[:3]
@@ -247,7 +252,7 @@ def main():
         summary = frontmatter.get("seo_description", "")
         feed_xml += "  <entry>\n"
         feed_xml += f"    <title>{html.escape(title)}</title>\n"
-        feed_xml += f"    <link href=\"{url}\" />\n"
+        feed_xml += f'    <link href="{url}" />\n'
         feed_xml += f"    <id>{url}</id>\n"
         feed_xml += f"    <updated>{date_iso}</updated>\n"
         if summary:
@@ -256,9 +261,10 @@ def main():
     feed_xml += "</feed>\n"
     (OUT / "feed.xml").write_text(feed_xml, encoding="utf-8")
 
-    # Generate robots.txt
-    robots_txt = f"User-agent: *\nAllow: /\n\nSitemap: {HOSTNAME}/sitemap.xml\n"
-    (OUT / "robots.txt").write_text(robots_txt, encoding="utf-8")
+    # robots.txt
+    (OUT / "robots.txt").write_text(
+        f"User-agent: *\nAllow: /\n\nSitemap: {HOSTNAME}/sitemap.xml\n", encoding="utf-8"
+    )
 
 
 if __name__ == "__main__":

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,347 +1,230 @@
-/* style.css — drop in root folder, build.py will copy it to /out */
-
-/* Base styles and variables */
 :root {
-  --body-font: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --max-width: 60ch;              /* keep line-length comfortable */
-  --accent: #0069ff;
-  
-  /* Light mode colors */
-  --bg-color: #fff;
-  --text-color: #222;
-  --text-muted: #666;
-  --text-lighter: #777;
-  --border-color: #eee;
-  --code-bg: #f5f5f5;
-  --bio-bg: #f8f8f8;
-  --shadow-color: rgba(0, 0, 0, 0.1);
+  --serif: "Source Serif 4", ui-serif, Charter, Georgia, "Times New Roman", serif;
+  --sans:  ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --mono:  "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --bg:    oklch(0.99 0.005 80);
+  --paper: oklch(0.98 0.008 80);
+  --text:  oklch(0.22 0.01 60);
+  --muted: oklch(0.55 0.01 60);
+  --rule:  oklch(0.90 0.01 60);
+  --link:  oklch(0.50 0.16 250);
+  --link-underline: oklch(0.50 0.16 250 / 0.35);
+  --code-bg: oklch(0.96 0.005 80);
 }
 
-/* Dark mode colors */
 [data-theme="dark"] {
-  --bg-color: #0f0f0f;
-  --text-color: #e4e4e4;
-  --text-muted: #a0a0a0;
-  --text-lighter: #888;
-  --border-color: #333;
-  --code-bg: #1a1a1a;
-  --bio-bg: #1a1a1a;
-  --shadow-color: rgba(255, 255, 255, 0.1);
-  --accent: #4a9eff;
+  --bg:    oklch(0.16 0.01 60);
+  --paper: oklch(0.20 0.01 60);
+  --text:  oklch(0.90 0.01 60);
+  --muted: oklch(0.62 0.01 60);
+  --rule:  oklch(0.30 0.01 60);
+  --link:  oklch(0.78 0.13 250);
+  --link-underline: oklch(0.78 0.13 250 / 0.35);
+  --code-bg: oklch(0.22 0.01 60);
 }
 
-/* Dark mode toggle button */
-.theme-toggle {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  background: var(--bio-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 50%;
-  width: 44px;
-  height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  font-size: 1.2rem;
-  transition: all 0.2s ease;
-  z-index: 1000;
-  box-shadow: 0 2px 8px var(--shadow-color);
-}
-
-.theme-toggle:hover {
-  transform: scale(1.05);
-  box-shadow: 0 4px 12px var(--shadow-color);
-}
-
-.theme-toggle:focus {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-/* Reset and base styles */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-html {
-  font-size: 20px;                /* bigger default (≈ 113 % of 16 px) */
-}
-
+*, *::before, *::after { box-sizing: border-box; }
+html { font-size: 19px; }
 body {
-  margin: 0;
-  font-family: var(--body-font);
-  line-height: 1.6;
-  color: var(--text-color);
-  background: var(--bg-color);
-  padding: 2rem;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  margin: 0; background: var(--bg); color: var(--text);
+  font-family: var(--serif); font-feature-settings: "kern", "liga", "onum";
+  line-height: 1.55; padding: 4rem 2rem 6rem;
+}
+.wrap { max-width: 640px; margin: 0 auto; }
+
+/* Masthead */
+.mast {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 2rem; margin-bottom: 4rem;
+}
+.mast .name {
+  font-family: var(--sans); font-weight: 600; letter-spacing: -0.01em;
+  font-size: 1.05rem; color: var(--text); text-decoration: none;
+}
+.mast nav {
+  font-family: var(--sans); font-size: 0.9rem;
+  display: flex; align-items: center; gap: 1.25rem;
+}
+.mast nav a { color: var(--muted); text-decoration: none; }
+.mast nav a:hover, .mast nav a.active { color: var(--text); }
+.mast nav button.theme {
+  background: none; border: none; cursor: pointer;
+  padding: 0; margin: 0; color: var(--muted);
+  width: 18px; height: 18px; display: inline-grid; place-items: center;
+  border-radius: 50%; transition: color 120ms ease, transform 200ms ease;
+}
+.mast nav button.theme:hover { color: var(--text); transform: rotate(-15deg); }
+.mast nav button.theme svg { width: 16px; height: 16px; display: block; }
+.mast nav button.theme .moon { display: block; }
+.mast nav button.theme .sun  { display: none; }
+[data-theme="dark"] .mast nav button.theme .moon { display: none; }
+[data-theme="dark"] .mast nav button.theme .sun  { display: block; }
+
+/* Bio block */
+.bio-inline {
+  display: flex; align-items: flex-start; gap: 1rem; margin: 0 0 3.5rem;
+}
+.bio-inline img {
+  width: 56px; height: 56px; border-radius: 50%;
+  object-fit: cover; flex-shrink: 0;
+}
+.bio-inline .body { flex: 1; }
+.bio-inline p {
+  margin: 0; color: var(--text); font-family: var(--mono); font-size: 0.82rem;
+  line-height: 1.55;
+}
+.bio-inline p::before { content: "// "; color: var(--muted); }
+.bio-inline .social { display: flex; gap: 0.7rem; margin-top: 0.5rem; }
+.bio-inline .social a { width: 14px; height: 14px; opacity: 0.45; }
+.bio-inline .social a:hover { opacity: 1; }
+.bio-inline .social img { width: 100%; height: 100%; }
+[data-theme="dark"] .bio-inline .social img { filter: invert(0.9); }
+
+/* Index */
+h1.page-title {
+  font-weight: 600; font-size: 1.4rem; letter-spacing: -0.01em; margin: 0 0 2rem;
+  display: flex; align-items: baseline; justify-content: space-between; gap: 1rem;
+}
+h1.page-title .count {
+  font-family: var(--mono); font-size: 0.78rem; color: var(--muted);
+  font-weight: 400; font-variant-numeric: tabular-nums;
+}
+.year-block { margin-bottom: 2.5rem; }
+.year-block h2 {
+  font-family: var(--mono); font-weight: 400; font-size: 0.78rem;
+  color: var(--muted); margin: 0 0 0.75rem; letter-spacing: 0.05em;
+}
+ul.posts { list-style: none; padding: 0; margin: 0; }
+ul.posts li {
+  display: grid; grid-template-columns: 1fr auto; gap: 1.5rem;
+  align-items: baseline; padding: 0.55rem 0;
+  border-top: 1px solid var(--rule);
+}
+ul.posts li:last-child { border-bottom: 1px solid var(--rule); }
+ul.posts a {
+  color: var(--text); text-decoration: none; line-height: 1.4;
+  text-wrap: pretty;
+}
+ul.posts a:hover { color: var(--link); }
+ul.posts time {
+  font-family: var(--mono); font-size: 0.78rem; color: var(--muted);
+  font-variant-numeric: tabular-nums; white-space: nowrap; letter-spacing: 0.01em;
 }
 
-/* Typography */
-h1, h2, h3, h4 {
-  line-height: 1.3;
-  margin: 1.5rem 0 1rem;
-  font-weight: 700;
-  color: var(--text-color);
+/* Article */
+article .post-meta {
+  font-family: var(--mono); font-size: 0.78rem; color: var(--muted);
+  margin: 0 0 1rem; display: flex; gap: 1.25rem; flex-wrap: wrap;
+  font-variant-numeric: tabular-nums;
 }
-
-.post-date {
-  display: block;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  margin: -0.5rem 0 2rem;
+article h1.post-title {
+  font-weight: 600; font-size: 1.9rem; line-height: 1.2; letter-spacing: -0.015em;
+  margin: 0 0 1.25rem; text-wrap: balance;
 }
-
-a {
-  color: var(--accent);
-  text-decoration: none;
+article p.dek {
+  font-family: var(--serif); font-style: italic; font-size: 1.1rem;
+  color: var(--muted); line-height: 1.5; margin: 0 0 2.5rem;
+  text-wrap: pretty;
 }
-
-/* Layout */
-.layout {
-  display: grid;
-  grid-template-columns: 1fr; /* Default to single column */
-  grid-template-areas: /* Define areas for mobile */
-      "bio"
-      "main";
-  gap: 2rem; /* Adjusted gap for mobile */
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1rem; /* Add padding for mobile */
+article p { margin: 1.1rem 0; text-wrap: pretty; }
+article a {
+  color: var(--link); text-decoration: underline;
+  text-decoration-color: var(--link-underline); text-underline-offset: 3px;
 }
-
-.main-content {
-  grid-area: main; /* Assign to main area */
-  max-width: var(--max-width);
+article a:hover { text-decoration-color: var(--link); }
+article h2 {
+  font-weight: 600; font-size: 1.15rem; margin: 2.5rem 0 0.5rem;
+  letter-spacing: -0.005em;
 }
+article em { font-style: italic; }
 
-/* Navigation */
-nav {
-  margin-bottom: 2rem;
-}
-
-nav a {
-  color: var(--accent);
-  font-weight: 600;
-}
-
-.main-nav {
-  margin: 0.5rem 0 0;
-}
-
-.main-nav ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.main-nav li {
-  line-height: 1.4;
-}
-
-.main-nav a {
-  font-size: 0.9rem;
-}
-
-.main-nav a:hover {
-  text-decoration: underline;
+/* Figures */
+figure { margin: 2rem 0; }
+figcaption {
+  font-family: var(--sans); font-size: 0.82rem; color: var(--muted);
+  margin-top: 0.6rem; text-align: center;
 }
 
 /* Code blocks */
 code, pre {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--mono);
   background: var(--code-bg);
-  color: var(--text-color);
-  transition: background-color 0.2s ease, color 0.2s ease;
+  color: var(--text);
 }
-
+code {
+  font-size: 0.85em;
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
 pre {
   padding: 0.75rem 1rem;
   overflow-x: auto;
   border-radius: 4px;
+  font-size: 0.85rem;
+  line-height: 1.5;
 }
-
-/* Bio section */
-.bio-section {
-    grid-area: bio; /* Assign to bio area for mobile */
-    /* position: sticky; REMOVE from base */
-    top: 2rem; /* Keep for when sticky is re-added */
-    height: fit-content;
-    padding: 1.5rem;
-    background: var(--bio-bg);
-    border-radius: 8px;
-    font-size: 0.9rem;
-    text-align: center;
-    transition: background-color 0.2s ease;
-    border: 1px solid var(--border-color);
-}
-
-.bio-image {
-    width: 120px;
-    height: 120px;
-    border-radius: 50%;
-    object-fit: cover;
-    margin: 0 auto 1rem;
-    display: block;
-}
-
-.bio-content {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.bio-section hr {
-    border: none;
-    border-top: 1px solid var(--border-color);
-    margin: 1rem 0 0.5rem;
-}
-
-/* Social links */
-.social-links {
-    display: flex;
-    gap: 1rem;
-    margin-top: 1rem;
-    justify-content: center;
-}
-
-.social-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    color: var(--accent);
-    transition: opacity 0.2s ease;
-}
-
-.social-link:hover {
-    opacity: 0.8;
-}
-
-.social-icon {
-    width: 100%;
-    height: 100%;
-}
-
-/* Content wrapper and sidebar */
-.content-wrapper {
-    display: grid;
-    grid-template-columns: 1fr; /* Default to single column */
-    gap: 1.5rem; /* Adjusted gap */
-    margin-top: 2rem;
-}
-
-.sidebar {
-    position: sticky;
-    top: 2rem;
-    height: fit-content;
-}
-
-.sidebar .pages {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.sidebar .pages li {
-    margin-bottom: 0.5rem;
-}
-
-.sidebar .pages a {
-    color: var(--accent);
-    font-size: 0.9rem;
-}
-
-.sidebar .pages a:hover {
-    text-decoration: underline;
+pre code {
+  padding: 0;
+  background: none;
 }
 
 /* Footer */
-footer {
-    margin-top: 3rem;
-    font-size: 0.9rem;
-    color: var(--text-lighter);
-    text-align: center;
-    border-top: 1px solid var(--border-color);
-    padding-top: 1rem;
-    transition: color 0.2s ease, border-color 0.2s ease;
+footer.colophon {
+  margin-top: 5rem; padding-top: 1.5rem; border-top: 1px solid var(--rule);
+  font-family: var(--mono); font-size: 0.75rem; color: var(--muted);
+  display: flex; justify-content: space-between;
 }
 
-/* Accessibility */
-a:focus,
-button:focus,
-input:focus,
-select:focus,
-textarea:focus,
-[tabindex]:focus {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.25);
-}
-
-/* Dark mode syntax highlighting */
-[data-theme="dark"] .codehilite .k { color: #ff79c6; font-weight: bold } /* Keyword */
-[data-theme="dark"] .codehilite .s { color: #f1fa8c } /* String */
-[data-theme="dark"] .codehilite .c { color: #6272a4; font-style: italic } /* Comment */
-[data-theme="dark"] .codehilite .n { color: #f8f8f2 } /* Name */
-[data-theme="dark"] .codehilite .o { color: #ff79c6 } /* Operator */
-[data-theme="dark"] .codehilite .p { color: #f8f8f2 } /* Punctuation */
-[data-theme="dark"] .codehilite .ch { color: #6272a4; font-style: italic } /* Comment.Hashbang */
-[data-theme="dark"] .codehilite .cm { color: #6272a4; font-style: italic } /* Comment.Multiline */
-[data-theme="dark"] .codehilite .cp { color: #ff79c6 } /* Comment.Preproc */
-[data-theme="dark"] .codehilite .c1 { color: #6272a4; font-style: italic } /* Comment.Single */
-[data-theme="dark"] .codehilite .cs { color: #6272a4; background-color: #44475a } /* Comment.Special */
-[data-theme="dark"] .codehilite .kc { color: #ff79c6; font-weight: bold } /* Keyword.Constant */
-[data-theme="dark"] .codehilite .kd { color: #ff79c6; font-weight: bold } /* Keyword.Declaration */
-
-/* Light mode syntax highlighting */
-.codehilite .k { color: #007020; font-weight: bold } /* Keyword */
-.codehilite .s { color: #4070a0 } /* String */
-.codehilite .c { color: #60a0b0; font-style: italic } /* Comment */
-.codehilite .n { color: #007020 } /* Name */
-.codehilite .o { color: #666666 } /* Operator */
-.codehilite .p { color: #666666 } /* Punctuation */
-.codehilite .ch { color: #60a0b0; font-style: italic } /* Comment.Hashbang */
-.codehilite .cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
-.codehilite .cp { color: #007020 } /* Comment.Preproc */
-.codehilite .c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
-.codehilite .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
-.codehilite .kc { color: #007020; font-weight: bold } /* Keyword.Constant */
-.codehilite .kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
-
-/* Media Queries */
-@media (min-width: 768px) {
-    .layout {
-        grid-template-columns: 1fr 300px;
-        grid-template-areas: /* Define areas for desktop */
-            "main aside";
-        gap: 3rem;
-        padding: 2rem; /* Restore original padding */
-    }
-
-    .bio-section {
-        grid-area: aside; /* Assign to aside area for desktop */
-        position: sticky; /* Apply sticky only for desktop */
-    }
-
-    .content-wrapper {
-        grid-template-columns: 1fr 200px;
-        gap: 2rem;
-    }
-
-    .main-nav ul {
-        gap: 1.5rem; /* Restore original gap */
-    }
-}
-
-/* Add responsive image styles */
+/* Images */
 img {
   max-width: 100%;
   height: auto;
   display: block;
+}
+
+/* Accessibility */
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
+
+/* Dark mode syntax highlighting */
+[data-theme="dark"] .codehilite .k { color: #ff79c6; font-weight: bold }
+[data-theme="dark"] .codehilite .s { color: #f1fa8c }
+[data-theme="dark"] .codehilite .c { color: #6272a4; font-style: italic }
+[data-theme="dark"] .codehilite .n { color: #f8f8f2 }
+[data-theme="dark"] .codehilite .o { color: #ff79c6 }
+[data-theme="dark"] .codehilite .p { color: #f8f8f2 }
+[data-theme="dark"] .codehilite .ch { color: #6272a4; font-style: italic }
+[data-theme="dark"] .codehilite .cm { color: #6272a4; font-style: italic }
+[data-theme="dark"] .codehilite .cp { color: #ff79c6 }
+[data-theme="dark"] .codehilite .c1 { color: #6272a4; font-style: italic }
+[data-theme="dark"] .codehilite .cs { color: #6272a4; background-color: #44475a }
+[data-theme="dark"] .codehilite .kc { color: #ff79c6; font-weight: bold }
+[data-theme="dark"] .codehilite .kd { color: #ff79c6; font-weight: bold }
+
+/* Light mode syntax highlighting */
+.codehilite .k { color: #007020; font-weight: bold }
+.codehilite .s { color: #4070a0 }
+.codehilite .c { color: #60a0b0; font-style: italic }
+.codehilite .n { color: #007020 }
+.codehilite .o { color: #666666 }
+.codehilite .p { color: #666666 }
+.codehilite .ch { color: #60a0b0; font-style: italic }
+.codehilite .cm { color: #60a0b0; font-style: italic }
+.codehilite .cp { color: #007020 }
+.codehilite .c1 { color: #60a0b0; font-style: italic }
+.codehilite .cs { color: #60a0b0; background-color: #fff0f0 }
+.codehilite .kc { color: #007020; font-weight: bold }
+.codehilite .kd { color: #007020; font-weight: bold }
+
+/* Responsive */
+@media (max-width: 480px) {
+  body { padding: 2rem 1.25rem 4rem; }
+  .mast { flex-wrap: wrap; gap: 0.75rem; margin-bottom: 3rem; }
+  h1.page-title { font-size: 1.2rem; }
+  article h1.post-title { font-size: 1.5rem; }
+  ul.posts li { grid-template-columns: 1fr; gap: 0.25rem; }
+  ul.posts time { justify-self: start; }
 }

--- a/static/templates/template.html
+++ b/static/templates/template.html
@@ -5,101 +5,68 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{title}}</title>
     <meta name="description" content="{{seo_description}}">
-    
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{title}}">
     <meta property="og:description" content="{{seo_description}}">
     <meta property="og:image" content="{{seo_image}}">
-    
+
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{title}}">
     <meta name="twitter:description" content="{{seo_description}}">
     <meta name="twitter:image" content="{{seo_image}}">
-    
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="alternate" type="application/atom+xml" title="{{site_name}}" href="/feed.xml">
-    
+
     <!-- Umami Analytics -->
     <script defer src="https://cloud.umami.is/script.js" data-website-id="{{umami_website_id}}"></script>
-    
-    <!-- Theme initialization script (runs immediately to prevent flash) -->
+
+    <!-- Theme initialization (prevents flash) -->
     <script>
         (function() {
-            const savedTheme = localStorage.getItem('theme') || 
+            var t = localStorage.getItem('theme') ||
                 (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-            document.documentElement.setAttribute('data-theme', savedTheme);
+            document.documentElement.setAttribute('data-theme', t);
         })();
     </script>
 </head>
 <body>
-<!-- Dark mode toggle button -->
-<button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
-    <span id="theme-icon">🌙</span>
-</button>
-
-<div class="layout">
-    <div class="main-content">
-        <h1><a href="/">{{site_name}}</a></h1>
-        <main>
-            {{main_heading}}
-            {{content}}
-        </main>
-        <footer>©️ {{year}} {{site_name}}</footer>
-    </div>
-    <aside class="bio-section">
-        <img src="{{bio.image}}" alt="{{bio.name}}" class="bio-image">
-        <p>{{bio.bio}}</p>
-        <div class="social-links">
-            <a href="{{bio.social.x.url}}" class="social-link" target="_blank" rel="noopener noreferrer">
-                <img src="{{bio.social.x.icon}}" alt="X" class="social-icon">
-            </a>
-            <a href="{{bio.social.linkedin.url}}" class="social-link" target="_blank" rel="noopener noreferrer">
-                <img src="{{bio.social.linkedin.icon}}" alt="LinkedIn" class="social-icon">
-            </a>
-            <a href="{{bio.social.github.url}}" class="social-link" target="_blank" rel="noopener noreferrer">
-                <img src="{{bio.social.github.icon}}" alt="GitHub" class="social-icon">
-            </a>
-            <a href="{{bio.social.rss.url}}" class="social-link" rel="noopener noreferrer">
-                <img src="{{bio.social.rss.icon}}" alt="RSS" class="social-icon">
-            </a>
-        </div>
-        <hr>
-        <nav class="main-nav">
+<div class="wrap">
+    <header class="mast">
+        <a href="/" class="name">{{site_name}}</a>
+        <nav>
             {{nav}}
+            <button class="theme" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+                <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 3v1.5M12 19.5V21M4.2 4.2l1.06 1.06M18.74 18.74l1.06 1.06M3 12h1.5M19.5 12H21M4.2 19.8l1.06-1.06M18.74 5.26l1.06-1.06"/></svg>
+            </button>
         </nav>
-    </aside>
+    </header>
+    <main>
+        {{content}}
+    </main>
+    <footer class="colophon">
+        <span>&copy; {{year}} {{site_name}}</span>
+    </footer>
 </div>
 
-<!-- Dark mode toggle functionality -->
 <script>
     (function() {
-        const themeToggle = document.getElementById('theme-toggle');
-        const themeIcon = document.getElementById('theme-icon');
-        
-        function updateThemeIcon(theme) {
-            themeIcon.textContent = theme === 'dark' ? '☀️' : '🌙';
+        var toggle = document.getElementById('theme-toggle');
+        function setTheme(t) {
+            document.documentElement.setAttribute('data-theme', t);
+            localStorage.setItem('theme', t);
         }
-        
-        function setTheme(theme) {
-            document.documentElement.setAttribute('data-theme', theme);
-            localStorage.setItem('theme', theme);
-            updateThemeIcon(theme);
-        }
-        
-        // Initialize icon based on current theme
-        const currentTheme = document.documentElement.getAttribute('data-theme');
-        updateThemeIcon(currentTheme);
-        
-        // Toggle theme on button click
-        themeToggle.addEventListener('click', function() {
-            const currentTheme = document.documentElement.getAttribute('data-theme');
-            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-            setTheme(newTheme);
+        toggle.addEventListener('click', function() {
+            var cur = document.documentElement.getAttribute('data-theme') || 'light';
+            setTheme(cur === 'dark' ? 'light' : 'dark');
         });
-        
-        // Listen for system theme changes
         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
             if (!localStorage.getItem('theme')) {
                 setTheme(e.matches ? 'dark' : 'light');


### PR DESCRIPTION
Replaces the two-column sidebar layout with a single-column typographic
design: Source Serif 4 body, JetBrains Mono for dates/meta, inline bio
with // prefix, ISO dates, post count, read-time estimates, and an
italic dek on post pages. Dark mode toggle moves from floating button
to an inline sun/moon icon in the nav.

https://claude.ai/code/session_01JUFGa7WseGPmVy3M3fSxud