### PR TITLE
Reorganize books list by read date in reverse chronological order

### DIFF
--- a/pages/books-read.md
+++ b/pages/books-read.md
@@ -3,20 +3,20 @@
 ## Non-fiction
 
 ### AI & Machine Learning
+- *[The StatQuest Illustrated Guide to Neural Networks and AI: With hands-on examples in PyTorch!!!](https://www.goodreads.com/book/show/223294677)* — Josh Starmer *(read: 2025-12-20)*
+- *[The StatQuest Illustrated Guide To Machine Learning](https://www.goodreads.com/book/show/61063119)* — Josh Starmer *(read: 2025-06-27)*
+- *[What Is ChatGPT Doing... and Why Does It Work?](https://www.goodreads.com/book/show/123245371)* — Stephen Wolfram *(read: 2024-03-27)*
 - *[How to Create a Mind: The Secret of Human Thought Revealed](https://www.goodreads.com/book/show/13589153)* — Ray Kurzweil *(read: 2022-05-29)*
 - *[Superintelligence: Paths, Dangers, Strategies](https://www.goodreads.com/book/show/20527133)* — Nick Bostrom
-- *[The StatQuest Illustrated Guide To Machine Learning](https://www.goodreads.com/book/show/61063119)* — Josh Starmer *(read: 2025-06-27)*
-- *[The StatQuest Illustrated Guide to Neural Networks and AI: With hands-on examples in PyTorch!!!](https://www.goodreads.com/book/show/223294677)* — Josh Starmer *(read: 2025-12-20)*
-- *[What Is ChatGPT Doing... and Why Does It Work?](https://www.goodreads.com/book/show/123245371)* — Stephen Wolfram *(read: 2024-03-27)*
 
 ### Art, Music & Culture
 - *[Graded Go Problems for Beginners Volume One Introductory Problems 30 Kyu to 25 Kyu (Graded Go Problems for Beginners, #1)](https://www.goodreads.com/book/show/910564)* — Yoshinori Kano *(read: 2023-03-20)*
 - *[The Culture Map: Breaking Through the Invisible Boundaries of Global Business](https://www.goodreads.com/book/show/22085568)* — Erin Meyer
 
 ### Biology & Evolution
+- *[Other Minds](https://www.goodreads.com/book/show/28116739)* — Peter Godfrey-Smith *(read: 2019-12-26)*
 - *[From Bacteria to Bach and Back: The Evolution of Minds](https://www.goodreads.com/book/show/35167699)* — Daniel C. Dennett
 - *[Metazoa: Animal Life and the Birth of the Mind](https://www.goodreads.com/book/show/50403455)* — Peter Godfrey-Smith
-- *[Other Minds](https://www.goodreads.com/book/show/28116739)* — Peter Godfrey-Smith *(read: 2019-12-26)*
 - *[The Freeze-Frame Revolution](https://www.goodreads.com/book/show/36510759)* — Peter Watts
 - *[The Selfish Gene](https://www.goodreads.com/book/show/61535)* — Richard Dawkins
 
@@ -28,19 +28,19 @@
 - *[Prisoners of Geography: Ten Maps That Tell You Everything You Need to Know About Global Politics (Politics of Place, #1)](https://www.goodreads.com/book/show/25135194)* — Tim  Marshall *(read: 2022-01-31)*
 
 ### Health & Wellbeing
+- *[Four Thousand Weeks: Time Management for Mortals](https://www.goodreads.com/book/show/54785515)* — Oliver Burkeman *(read: 2024-06-27)*
+- *[The Coaching Habit: Say Less, Ask More & Change the Way You Lead Forever](https://www.goodreads.com/book/show/29342515)* — Michael Bungay Stanier *(read: 2024-04-23)*
+- *[Radical Candor: Be a Kickass Boss Without Losing Your Humanity](https://www.goodreads.com/book/show/29939161)* — Kim Malone Scott *(read: 2024-01-09)*
 - *[Atomic Habits: An Easy & Proven Way to Build Good Habits & Break Bad Ones](https://www.goodreads.com/book/show/40121378)* — James Clear
 - *[Crucial Conversations: Tools for Talking When Stakes are High](https://www.goodreads.com/book/show/15014)* — Kerry Patterson
-- *[Four Thousand Weeks: Time Management for Mortals](https://www.goodreads.com/book/show/54785515)* — Oliver Burkeman *(read: 2024-06-27)*
-- *[Radical Candor: Be a Kickass Boss Without Losing Your Humanity](https://www.goodreads.com/book/show/29939161)* — Kim Malone Scott *(read: 2024-01-09)*
-- *[The Coaching Habit: Say Less, Ask More & Change the Way You Lead Forever](https://www.goodreads.com/book/show/29342515)* — Michael Bungay Stanier *(read: 2024-04-23)*
 
 ### History
+- *[Nexus: A Brief History of Information Networks from the Stone Age to AI](https://www.goodreads.com/book/show/204927599)* — Yuval Noah Harari *(read: 2025-06-17)*
+- *[Homo Deus: A History of Tomorrow](https://www.goodreads.com/book/show/31138556)* — Yuval Noah Harari *(read: 2018-08-13)*
+- *[Where Good Ideas Come From: The Natural History of Innovation](https://www.goodreads.com/book/show/8034188)* — Steven Johnson *(read: 2011-01-01)*
 - *[A Short History of Nearly Everything](https://www.goodreads.com/book/show/21)* — Bill Bryson
 - *[A Time Traveller's Guide to Our Next Ten Years](https://www.goodreads.com/book/show/22473133)* — Frans Cronje
-- *[Homo Deus: A History of Tomorrow](https://www.goodreads.com/book/show/31138556)* — Yuval Noah Harari *(read: 2018-08-13)*
-- *[Nexus: A Brief History of Information Networks from the Stone Age to AI](https://www.goodreads.com/book/show/204927599)* — Yuval Noah Harari *(read: 2025-06-17)*
 - *[Sapiens: A Brief History of Humankind](https://www.goodreads.com/book/show/23692271)* — Yuval Noah Harari
-- *[Where Good Ideas Come From: The Natural History of Innovation](https://www.goodreads.com/book/show/8034188)* — Steven Johnson *(read: 2011-01-01)*
 - *[Why the Dutch are Different: A Journey into the Hidden Heart of the Netherlands](https://www.goodreads.com/book/show/25860139)* — Ben Coates
 
 ### Mathematics
@@ -48,10 +48,10 @@
 - *[Chaos: Making a New Science](https://www.goodreads.com/book/show/64582)* — James Gleick *(read: 2008-11-09)*
 
 ### Neuroscience & Psychology
-- *[59 Seconds: Think a Little, Change a Lot](https://www.goodreads.com/book/show/6340948)* — Richard Wiseman *(read: 2015-05-06)*
 - *[Being You: A New Science of Consciousness](https://www.goodreads.com/book/show/53036979)* — Anil Seth *(read: 2023-10-23)*
-- *[The Courage to Be Disliked: How to Free Yourself, Change Your Life and Achieve Real Happiness](https://www.goodreads.com/book/show/43306206)* — Ichiro Kishimi
 - *[The Man Who Mistook His Wife for a Hat and Other Clinical Tales](https://www.goodreads.com/book/show/63697)* — Oliver Sacks *(read: 2022-08-05)*
+- *[59 Seconds: Think a Little, Change a Lot](https://www.goodreads.com/book/show/6340948)* — Richard Wiseman *(read: 2015-05-06)*
+- *[The Courage to Be Disliked: How to Free Yourself, Change Your Life and Achieve Real Happiness](https://www.goodreads.com/book/show/43306206)* — Ichiro Kishimi
 - *[Thinking, Fast and Slow](https://www.goodreads.com/book/show/11468377)* — Daniel Kahneman
 
 ### Philosophy & Science
@@ -61,110 +61,110 @@
 - *[What Is This Thing Called Science?](https://www.goodreads.com/book/show/137314)* — Alan F. Chalmers
 
 ### Physics & Cosmology
-- *[Prince of Networks: Bruno Latour and Metaphysics](https://www.goodreads.com/book/show/6581757)* — Graham Harman *(read: 2015-05-06)*
-- *[The Demon-Haunted World: Science as a Candle in the Dark](https://www.goodreads.com/book/show/17349)* — Carl Sagan *(read: 2024-08-13)*
 - *[The Universe in a Box: Simulations and the Quest to Code the Cosmos](https://www.goodreads.com/book/show/62952127)* — Andrew Pontzen *(read: 2024-12-01)*
+- *[The Demon-Haunted World: Science as a Candle in the Dark](https://www.goodreads.com/book/show/17349)* — Carl Sagan *(read: 2024-08-13)*
+- *[Prince of Networks: Bruno Latour and Metaphysics](https://www.goodreads.com/book/show/6581757)* — Graham Harman *(read: 2015-05-06)*
 
 ### Politics & Society
-- *[21 Lessons for the 21st Century](https://www.goodreads.com/book/show/38820046)* — Yuval Noah Harari
 - *[Blue Like Jazz: Nonreligious Thoughts on Christian Spirituality](https://www.goodreads.com/book/show/7214)* — Donald Miller *(read: 2010-10-01)*
+- *[21 Lessons for the 21st Century](https://www.goodreads.com/book/show/38820046)* — Yuval Noah Harari
 - *[Factfulness: Ten Reasons We're Wrong About the World – and Why Things Are Better Than You Think](https://www.goodreads.com/book/show/34890015)* — Hans Rosling
 - *[The Wisdom of Crowds](https://www.goodreads.com/book/show/68143)* — James Surowiecki
 
 ### Software Engineering & Technology
-- *[Accelerate: Building and Scaling High Performing Technology Organizations](https://www.goodreads.com/book/show/35747076)* — Nicole Forsgren
-- *[Bitcoin and Cryptocurrency Technologies: A Comprehensive Introduction](https://www.goodreads.com/book/show/29452533)* — Arvind Narayanan
+- *[Sooner Safer Happier: Antipatterns and Patterns for Business Agility](https://www.goodreads.com/book/show/50343488)* — Jonathan  Smart *(read: 2024-05-26)*
 - *[Continuous Discovery Habits: Discover Products that Create Customer Value and Business Value](https://www.goodreads.com/book/show/58046715)* — Teresa  Torres *(read: 2024-01-01)*
 - *[Escaping the Build Trap: How Effective Product Management Creates Real Value](https://www.goodreads.com/book/show/42611483)* — Melissa Perri *(read: 2024-01-01)*
-- *[Finite and Infinite Games: A Vision of Life as Play and Possibility](https://www.goodreads.com/book/show/189989)* — James P. Carse
 - *[Good Strategy Bad Strategy: The Difference and Why It Matters](https://www.goodreads.com/book/show/11721966)* — Richard P. Rumelt *(read: 2022-12-31)*
-- *[How to Measure Anything: Finding the Value of "Intangibles" in Business](https://www.goodreads.com/book/show/444653)* — Douglas W. Hubbard
+- *[No Rules Rules: Netflix and the Culture of Reinvention](https://www.goodreads.com/book/show/49099937)* — Reed Hastings *(read: 2022-01-19)*
+- *[Strategize: Product Strategy and Product Roadmap Practices for the Digital Age](https://www.goodreads.com/book/show/29336329)* — Roman Pichler *(read: 2022-01-19)*
 - *[Liberating the Corporate Soul : Building a Visionary Organization](https://www.goodreads.com/book/show/194644)* — Richard Barrett *(read: 2011-12-12)*
+- *[Accelerate: Building and Scaling High Performing Technology Organizations](https://www.goodreads.com/book/show/35747076)* — Nicole Forsgren
+- *[Bitcoin and Cryptocurrency Technologies: A Comprehensive Introduction](https://www.goodreads.com/book/show/29452533)* — Arvind Narayanan
+- *[Finite and Infinite Games: A Vision of Life as Play and Possibility](https://www.goodreads.com/book/show/189989)* — James P. Carse
+- *[How to Measure Anything: Finding the Value of "Intangibles" in Business](https://www.goodreads.com/book/show/444653)* — Douglas W. Hubbard
 - *[Measure What Matters](https://www.goodreads.com/book/show/39286958)* — John Doerr
 - *[Moving the Needle with Lean OKRs](https://www.goodreads.com/book/show/59464293)* — Bart den Haak
-- *[No Rules Rules: Netflix and the Culture of Reinvention](https://www.goodreads.com/book/show/49099937)* — Reed Hastings *(read: 2022-01-19)*
-- *[Sooner Safer Happier: Antipatterns and Patterns for Business Agility](https://www.goodreads.com/book/show/50343488)* — Jonathan  Smart *(read: 2024-05-26)*
-- *[Strategize: Product Strategy and Product Roadmap Practices for the Digital Age](https://www.goodreads.com/book/show/29336329)* — Roman Pichler *(read: 2022-01-19)*
 - *[Team Topologies: Organizing Business and Technology Teams for Fast Flow](https://www.goodreads.com/book/show/44135420)* — Matthew    Skelton
 - *[The Lean Startup](https://www.goodreads.com/book/show/10127019)* — Eric Ries
 - *[The Phoenix Project: A Novel About IT, DevOps, and Helping Your Business Win](https://www.goodreads.com/book/show/17255186)* — Gene Kim
 
 ## Fiction
-- *[1984](https://www.goodreads.com/book/show/40961427)* — George Orwell
-- *[A Brief History of Time](https://www.goodreads.com/book/show/3869)* — Stephen W. Hawking *(read: 2025-07-05)*
-- *[A Clash of Kings  (A Song of Ice and Fire, #2)](https://www.goodreads.com/book/show/10572)* — George R.R. Martin *(read: 2005-12-01)*
-- *[A Dance with Dragons (A Song of Ice and Fire, #5)](https://www.goodreads.com/book/show/10664113)* — George R.R. Martin
-- *[A Feast for Crows (A Song of Ice and Fire, #4)](https://www.goodreads.com/book/show/13497)* — George R.R. Martin
-- *[A Game of Thrones (A Song of Ice and Fire, #1)](https://www.goodreads.com/book/show/13496)* — George R.R. Martin *(read: 2005-12-19)*
-- *[A Storm of Swords (A Song of Ice and Fire, #3)](https://www.goodreads.com/book/show/62291)* — George R.R. Martin *(read: 2008-11-09)*
-- *[A Tale of Two Cities](https://www.goodreads.com/book/show/1953)* — Charles Dickens *(read: 2006-01-01)*
+- *[There Is No Antimemetics Division](https://www.goodreads.com/book/show/54870256-there-is-no-antimemetics-division)* — qntm *(read: 2026-05-01)*
+- *[The MANIAC](https://www.goodreads.com/book/show/75665931)* — Benjamín Labatut *(read: 2026-04-22)*
 - *[A Wizard of Earthsea (Earthsea Cycle, #1)](https://www.goodreads.com/book/show/13642)* — Ursula K. Le Guin *(read: 2025-08-28)*
-- *[Accelerando](https://www.goodreads.com/book/show/17863)* — Charles Stross *(read: 2008-12-10)*
-- *[American Gods (American Gods, #1)](https://www.goodreads.com/book/show/4407)* — Neil Gaiman *(read: 2000-01-01)*
-- *[Anathem](https://www.goodreads.com/book/show/2845024)* — Neal Stephenson
-- *[Animal Farm](https://www.goodreads.com/book/show/170448)* — George Orwell
-- *[Blindness](https://www.goodreads.com/book/show/2526)* — José Saramago *(read: 2006-01-01)*
-- *[Chasm City](https://www.goodreads.com/book/show/89185)* — Alastair Reynolds *(read: 2011-01-01)*
+- *[A Brief History of Time](https://www.goodreads.com/book/show/3869)* — Stephen W. Hawking *(read: 2025-07-05)*
+- *[The Left Hand of Darkness](https://www.goodreads.com/book/show/18423)* — Ursula K. Le Guin *(read: 2025-02-02)*
+- *[Flatland: A Romance of Many Dimensions](https://www.goodreads.com/book/show/433567)* — Edwin A. Abbott *(read: 2024-12-07)*
+- *[Dragon's Egg (Cheela, #1)](https://www.goodreads.com/book/show/263466)* — Robert L. Forward *(read: 2024-11-26)*
+- *[Solar Lottery](https://www.goodreads.com/book/show/92504)* — Philip K. Dick *(read: 2024-09-06)*
+- *[Scale](https://www.goodreads.com/book/show/75462275)* — Greg Egan *(read: 2024-05-26)*
+- *[Rendezvous with Rama (Rama, #1)](https://www.goodreads.com/book/show/112537)* — Arthur C. Clarke *(read: 2024-03-22)*
 - *[Children of Time (Children of Time, #1)](https://www.goodreads.com/book/show/25499718)* — Adrian Tchaikovsky *(read: 2024-03-17)*
 - *[Death's End (The Three-Body Problem, #3)](https://www.goodreads.com/book/show/65645376)* — Cixin Liu *(read: 2023-12-10)*
-- *[Diary](https://www.goodreads.com/book/show/22284)* — Chuck Palahniuk *(read: 2004-01-01)*
-- *[Diaspora](https://www.goodreads.com/book/show/156785)* — Greg Egan
-- *[Distress](https://www.goodreads.com/book/show/13352262)* — Greg Egan *(read: 2019-11-14)*
-- *[Do Androids Dream of Electric Sheep?](https://www.goodreads.com/book/show/7082)* — Philip K. Dick *(read: 2005-01-01)*
-- *[Dragon's Egg (Cheela, #1)](https://www.goodreads.com/book/show/263466)* — Robert L. Forward *(read: 2024-11-26)*
-- *[Embassytown](https://www.goodreads.com/book/show/9265453)* — China Miéville *(read: 2011-09-13)*
+- *[The Waste Lands (The Dark Tower, #3)](https://www.goodreads.com/book/show/34084)* — Stephen  King *(read: 2022-12-31)*
 - *[Exhalation](https://www.goodreads.com/book/show/41160292)* — Ted Chiang *(read: 2022-12-26)*
-- *[Fahrenheit 451](https://www.goodreads.com/book/show/4381)* — Ray Bradbury
-- *[Flatland: A Romance of Many Dimensions](https://www.goodreads.com/book/show/433567)* — Edwin A. Abbott *(read: 2024-12-07)*
-- *[Glasshouse](https://www.goodreads.com/book/show/17866)* — Charles Stross *(read: 2008-12-26)*
-- *[GO: A Complete Introduction to the Game](https://www.goodreads.com/book/show/677753)* — Chikun Chō
-- *[House of Suns](https://www.goodreads.com/book/show/1126719)* — Alastair Reynolds
-- *[Incandescence](https://www.goodreads.com/book/show/2425528)* — Greg Egan
-- *[Instantiation](https://www.goodreads.com/book/show/50641444)* — Greg Egan *(read: 2020-07-27)*
-- *[Klara and the Sun](https://www.goodreads.com/book/show/54120408)* — Kazuo Ishiguro
-- *[Life of Pi](https://www.goodreads.com/book/show/4214)* — Yann Martel *(read: 2001-09-01)*
-- *[Maya](https://www.goodreads.com/book/show/25401)* — Jostein Gaarder *(read: 2008-11-09)*
-- *[Perdido Street Station (New Crobuzon, #1)](https://www.goodreads.com/book/show/6186642)* — China Miéville *(read: 2011-08-31)*
-- *[Permutation City](https://www.goodreads.com/book/show/15796130)* — Greg Egan *(read: 2018-08-23)*
+- *[Stories of Your Life and Others](https://www.goodreads.com/book/show/223380)* — Ted Chiang *(read: 2022-08-05)*
+- *[The Drawing of the Three (The Dark Tower, #2)](https://www.goodreads.com/book/show/5094)* — Stephen  King *(read: 2022-05-01)*
 - *[Project Hail Mary](https://www.goodreads.com/book/show/54493401)* — Andy Weir *(read: 2021-12-28)*
+- *[Where the Crawdads Sing](https://www.goodreads.com/book/show/42583886)* — Delia Owens *(read: 2021-12-28)*
+- *[Instantiation](https://www.goodreads.com/book/show/50641444)* — Greg Egan *(read: 2020-07-27)*
+- *[Distress](https://www.goodreads.com/book/show/13352262)* — Greg Egan *(read: 2019-11-14)*
+- *[Permutation City](https://www.goodreads.com/book/show/15796130)* — Greg Egan *(read: 2018-08-23)*
 - *[Quarantine](https://www.goodreads.com/book/show/20617123)* — Greg Egan *(read: 2018-08-04)*
 - *[Reamde](https://www.goodreads.com/book/show/10552338)* — Neal Stephenson *(read: 2015-05-06)*
 - *[Redemption Ark (Revelation Space, #2)](https://www.goodreads.com/book/show/89190)* — Alastair Reynolds *(read: 2011-12-12)*
-- *[Rendezvous with Rama (Rama, #1)](https://www.goodreads.com/book/show/112537)* — Arthur C. Clarke *(read: 2024-03-22)*
+- *[Embassytown](https://www.goodreads.com/book/show/9265453)* — China Miéville *(read: 2011-09-13)*
+- *[Perdido Street Station (New Crobuzon, #1)](https://www.goodreads.com/book/show/6186642)* — China Miéville *(read: 2011-08-31)*
+- *[Chasm City](https://www.goodreads.com/book/show/89185)* — Alastair Reynolds *(read: 2011-01-01)*
 - *[Revelation Space (Revelation Space, #1)](https://www.goodreads.com/book/show/89187)* — Alastair Reynolds *(read: 2011-01-01)*
-- *[Scale](https://www.goodreads.com/book/show/75462275)* — Greg Egan *(read: 2024-05-26)*
-- *[Schild's Ladder](https://www.goodreads.com/book/show/156780)* — Greg Egan
-- *[Singularity Sky (Eschaton, #1)](https://www.goodreads.com/book/show/81992)* — Charles Stross *(read: 2010-02-25)*
-- *[Snow Crash](https://www.goodreads.com/book/show/877977)* — Neal Stephenson
-- *[Solar Lottery](https://www.goodreads.com/book/show/92504)* — Philip K. Dick *(read: 2024-09-06)*
-- *[Sophie's World](https://www.goodreads.com/book/show/10959)* — Jostein Gaarder *(read: 2000-01-01)*
-- *[Stories of Your Life and Others](https://www.goodreads.com/book/show/223380)* — Ted Chiang *(read: 2022-08-05)*
-- *[Teranesia](https://www.goodreads.com/book/show/156787)* — Greg Egan
+- *[The Windup Girl](https://www.goodreads.com/book/show/6597651)* — Paolo Bacigalupi *(read: 2010-12-07)*
 - *[Terminal World](https://www.goodreads.com/book/show/6237781)* — Alastair Reynolds *(read: 2010-09-01)*
+- *[Singularity Sky (Eschaton, #1)](https://www.goodreads.com/book/show/81992)* — Charles Stross *(read: 2010-02-25)*
+- *[Glasshouse](https://www.goodreads.com/book/show/17866)* — Charles Stross *(read: 2008-12-26)*
+- *[Accelerando](https://www.goodreads.com/book/show/17863)* — Charles Stross *(read: 2008-12-10)*
+- *[A Storm of Swords (A Song of Ice and Fire, #3)](https://www.goodreads.com/book/show/62291)* — George R.R. Martin *(read: 2008-11-09)*
+- *[Maya](https://www.goodreads.com/book/show/25401)* — Jostein Gaarder *(read: 2008-11-09)*
+- *[The White Tiger](https://www.goodreads.com/book/show/1768603)* — Aravind Adiga *(read: 2008-11-09)*
+- *[We](https://www.goodreads.com/book/show/76171)* — Yevgeny Zamyatin *(read: 2008-07-10)*
+- *[Zen and the Art of Motorcycle Maintenance: An Inquiry Into Values](https://www.goodreads.com/book/show/4804840)* — Robert M. Pirsig *(read: 2007-12-19)*
+- *[The Great Gatsby](https://www.goodreads.com/book/show/4671)* — F. Scott Fitzgerald *(read: 2007-01-01)*
+- *[A Tale of Two Cities](https://www.goodreads.com/book/show/1953)* — Charles Dickens *(read: 2006-01-01)*
+- *[Blindness](https://www.goodreads.com/book/show/2526)* — José Saramago *(read: 2006-01-01)*
+- *[A Game of Thrones (A Song of Ice and Fire, #1)](https://www.goodreads.com/book/show/13496)* — George R.R. Martin *(read: 2005-12-19)*
+- *[A Clash of Kings  (A Song of Ice and Fire, #2)](https://www.goodreads.com/book/show/10572)* — George R.R. Martin *(read: 2005-12-01)*
+- *[Do Androids Dream of Electric Sheep?](https://www.goodreads.com/book/show/7082)* — Philip K. Dick *(read: 2005-01-01)*
+- *[The Demolished Man](https://www.goodreads.com/book/show/76740)* — Alfred Bester *(read: 2005-01-01)*
+- *[Diary](https://www.goodreads.com/book/show/22284)* — Chuck Palahniuk *(read: 2004-01-01)*
+- *[The Ringmaster's Daughter](https://www.goodreads.com/book/show/25402)* — Jostein Gaarder *(read: 2004-01-01)*
+- *[To Kill a Mockingbird](https://www.goodreads.com/book/show/2206723)* — Harper Lee *(read: 2004-01-01)*
+- *[Life of Pi](https://www.goodreads.com/book/show/4214)* — Yann Martel *(read: 2001-09-01)*
+- *[The Hobbit, or There and Back Again](https://www.goodreads.com/book/show/5907)* — J.R.R. Tolkien *(read: 2001-01-01)*
+- *[Wonder Boys](https://www.goodreads.com/book/show/16707)* — Michael Chabon *(read: 2001-01-01)*
+- *[American Gods (American Gods, #1)](https://www.goodreads.com/book/show/4407)* — Neil Gaiman *(read: 2000-01-01)*
+- *[Sophie's World](https://www.goodreads.com/book/show/10959)* — Jostein Gaarder *(read: 2000-01-01)*
+- *[The Lord of the Rings](https://www.goodreads.com/book/show/33)* — J.R.R. Tolkien *(read: 2000-01-01)*
+- *[Through a Glass, Darkly](https://www.goodreads.com/book/show/25405)* — Jostein Gaarder *(read: 2000-01-01)*
+- *[1984](https://www.goodreads.com/book/show/40961427)* — George Orwell
+- *[A Dance with Dragons (A Song of Ice and Fire, #5)](https://www.goodreads.com/book/show/10664113)* — George R.R. Martin
+- *[A Feast for Crows (A Song of Ice and Fire, #4)](https://www.goodreads.com/book/show/13497)* — George R.R. Martin
+- *[Anathem](https://www.goodreads.com/book/show/2845024)* — Neal Stephenson
+- *[Animal Farm](https://www.goodreads.com/book/show/170448)* — George Orwell
+- *[Diaspora](https://www.goodreads.com/book/show/156785)* — Greg Egan
+- *[Fahrenheit 451](https://www.goodreads.com/book/show/4381)* — Ray Bradbury
+- *[GO: A Complete Introduction to the Game](https://www.goodreads.com/book/show/677753)* — Chikun Chō
+- *[House of Suns](https://www.goodreads.com/book/show/1126719)* — Alastair Reynolds
+- *[Incandescence](https://www.goodreads.com/book/show/2425528)* — Greg Egan
+- *[Klara and the Sun](https://www.goodreads.com/book/show/54120408)* — Kazuo Ishiguro
+- *[Schild's Ladder](https://www.goodreads.com/book/show/156780)* — Greg Egan
+- *[Snow Crash](https://www.goodreads.com/book/show/877977)* — Neal Stephenson
+- *[Teranesia](https://www.goodreads.com/book/show/156787)* — Greg Egan
 - *[The Atrocity Archives (Laundry Files, #1)](https://www.goodreads.com/book/show/101869)* — Charles Stross
 - *[The Curious Incident of the Dog in the Night-Time](https://www.goodreads.com/book/show/1618)* — Mark Haddon
 - *[The Dark Forest (The Three-Body Problem, #2)](https://www.goodreads.com/book/show/66562105)* — Liu Cixin
-- *[The Demolished Man](https://www.goodreads.com/book/show/76740)* — Alfred Bester *(read: 2005-01-01)*
-- *[The Drawing of the Three (The Dark Tower, #2)](https://www.goodreads.com/book/show/5094)* — Stephen  King *(read: 2022-05-01)*
 - *[The Fifth Season (The Broken Earth, #1)](https://www.goodreads.com/book/show/19161852)* — N.K. Jemisin
 - *[The Girl Who Played with Fire (Millennium #2)](https://www.goodreads.com/book/show/5060378)* — Stieg Larsson
 - *[The Girl With the Dragon Tattoo (Millennium #1)](https://www.goodreads.com/book/show/5291539)* — Stieg Larsson
-- *[The Great Gatsby](https://www.goodreads.com/book/show/4671)* — F. Scott Fitzgerald *(read: 2007-01-01)*
 - *[The Gunslinger (The Dark Tower, #1) separate](https://www.goodreads.com/book/show/43615)* — Stephen  King
-- *[The Hobbit, or There and Back Again](https://www.goodreads.com/book/show/5907)* — J.R.R. Tolkien *(read: 2001-01-01)*
-- *[The Left Hand of Darkness](https://www.goodreads.com/book/show/18423)* — Ursula K. Le Guin *(read: 2025-02-02)*
-- *[The Lord of the Rings](https://www.goodreads.com/book/show/33)* — J.R.R. Tolkien *(read: 2000-01-01)*
-- *[The MANIAC](https://www.goodreads.com/book/show/75665931)* — Benjamín Labatut *(read: 2026-04-22)*
-- *[The Ringmaster's Daughter](https://www.goodreads.com/book/show/25402)* — Jostein Gaarder *(read: 2004-01-01)*
 - *[The Shadow of the Torturer](https://www.goodreads.com/book/show/60211)* — Gene Wolfe
 - *[The Three-Body Problem (Remembrance of Earth's Past, #1)](https://www.goodreads.com/book/show/20518872)* — Liu Cixin
-- *[The Waste Lands (The Dark Tower, #3)](https://www.goodreads.com/book/show/34084)* — Stephen  King *(read: 2022-12-31)*
-- *[The White Tiger](https://www.goodreads.com/book/show/1768603)* — Aravind Adiga *(read: 2008-11-09)*
-- *[The Windup Girl](https://www.goodreads.com/book/show/6597651)* — Paolo Bacigalupi *(read: 2010-12-07)*
-- *[There Is No Antimemetics Division](https://www.goodreads.com/book/show/54870256-there-is-no-antimemetics-division)* — qntm *(read: 2026-05-01)*
-- *[Through a Glass, Darkly](https://www.goodreads.com/book/show/25405)* — Jostein Gaarder *(read: 2000-01-01)*
-- *[To Kill a Mockingbird](https://www.goodreads.com/book/show/2206723)* — Harper Lee *(read: 2004-01-01)*
-- *[We](https://www.goodreads.com/book/show/76171)* — Yevgeny Zamyatin *(read: 2008-07-10)*
-- *[Where the Crawdads Sing](https://www.goodreads.com/book/show/42583886)* — Delia Owens *(read: 2021-12-28)*
-- *[Wonder Boys](https://www.goodreads.com/book/show/16707)* — Michael Chabon *(read: 2001-01-01)*
-- *[Zen and the Art of Motorcycle Maintenance: An Inquiry Into Values](https://www.goodreads.com/book/show/4804840)* — Robert M. Pirsig *(read: 2007-12-19)*


### PR DESCRIPTION
## Summary
Reorganized the books read list to sort entries by read date in reverse chronological order (most recently read first), with unread books moved to the end of the list in alphabetical order.

## Changes Made
- Moved all books with read dates to the top of the list, sorted by date from newest (2026-05-01) to oldest (2000-01-01)
- Relocated books without read dates to the end of the list, maintaining alphabetical order
- This provides better visibility of recently completed reads while preserving the existing unread books collection

## Notable Details
- Books with future dates (2026, 2025) appear at the top, suggesting planned or anticipated reads
- The reorganization maintains all existing book metadata (titles, authors, Goodreads links, and read dates)
- Approximately 50+ books with read dates were reordered, while 40+ unread books were moved to the end

https://claude.ai/code/session_013i9XE46bxNmA8PejADr8v3