### PR TITLE
Add TownSquare presence widget site-wide

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -361,3 +361,69 @@ img {
   height: auto;
   display: block;
 }
+
+/* TownSquare presence widget — theming bridge (self-contained variables) */
+#townsquare-root {
+  margin: 2rem auto 0;
+}
+
+#townsquare-root#townsquare-root {
+  --scene: transparent;
+  --page: #efede9;
+  --surface: #fdf8f4;
+  --ink: #2a2926;
+  --you: #c8641f;
+  --tree-trunk: color-mix(in oklab, var(--text) 58%, var(--muted) 42%);
+  --tree-canopy: color-mix(in oklab, var(--text) 58%, var(--muted) 42%);
+  --other: #26241f;
+  --ground: rgba(42, 41, 38, 0.16);
+  --scene-edge: color-mix(in oklab, var(--scene) 88%, var(--page) 12%);
+  --you-deep: var(--you);
+  --text: var(--ink);
+  --muted: var(--ink);
+}
+#townsquare-root#townsquare-root[data-townsquare-theme="dark"] {
+  --scene: #242521;
+  --page: #181917;
+  --surface: #24231f;
+  --ink: #f2eee6;
+  --you: #df8a43;
+  --tree-trunk: color-mix(in oklab, var(--text) 58%, var(--muted) 42%);
+  --tree-canopy: color-mix(in oklab, var(--text) 58%, var(--muted) 42%);
+  --other: #ddd7cc;
+  --ground: rgba(242, 238, 230, 0.18);
+  --scene-edge: color-mix(in oklab, var(--scene) 88%, var(--page) 12%);
+  --you-deep: var(--you);
+  --text: var(--ink);
+  --muted: var(--ink);
+}
+@media (prefers-color-scheme: dark) {
+  #townsquare-root#townsquare-root:is(:not([data-townsquare-theme]), [data-townsquare-theme="auto"]) {
+  --scene: #242521;
+  --page: #181917;
+  --surface: #24231f;
+  --ink: #f2eee6;
+  --you: #df8a43;
+  --tree-trunk: color-mix(in oklab, var(--text) 58%, var(--muted) 42%);
+  --tree-canopy: color-mix(in oklab, var(--text) 58%, var(--muted) 42%);
+  --other: #ddd7cc;
+  --ground: rgba(242, 238, 230, 0.18);
+  --scene-edge: color-mix(in oklab, var(--scene) 88%, var(--page) 12%);
+  --you-deep: var(--you);
+  --text: var(--ink);
+  --muted: var(--ink);
+  }
+}
+#townsquare-root#townsquare-root .townsquare__stage {
+  background: linear-gradient(
+    180deg,
+    var(--scene) 0%,
+    var(--scene) 72%,
+    var(--scene-edge) 72%,
+    var(--page) 72.4%,
+    var(--page) 100%
+  );
+}
+#townsquare-root#townsquare-root .townsquare__ground {
+  background: var(--ground);
+}

--- a/static/templates/template.html
+++ b/static/templates/template.html
@@ -47,6 +47,20 @@
             {{content}}
         </main>
         <footer>©️ {{year}} {{site_name}}</footer>
+
+        <!-- TownSquare presence widget -->
+        <link rel="stylesheet" href="https://townsquare.cauenapier.com/widget.css" />
+        <div id="townsquare-root"></div>
+        <script type="module">
+          import { mountTownSquare } from "https://townsquare.cauenapier.com/townsquare.mjs";
+
+          mountTownSquare(document.getElementById("townsquare-root"), {
+            serverOrigin: "https://townsquare.cauenapier.com",
+            siteKey: "site_5uzYK6UdzyWi8nd0",
+            scene: {"benches":2,"benchXs":[0.2,0.72],"trees":1,"treeXs":[0.8],"lamps":1,"lampXs":[0.12],"birds":3},
+            theme: "host"
+          });
+        </script>
     </div>
     <aside class="bio-section">
         <img src="{{bio.image}}" alt="{{bio.name}}" class="bio-image">
@@ -81,16 +95,24 @@
         function updateThemeIcon(theme) {
             themeIcon.textContent = theme === 'dark' ? '☀️' : '🌙';
         }
-        
+
+        // Keep the TownSquare widget's theme in sync with the site toggle
+        function syncTownSquareTheme(theme) {
+            const root = document.getElementById('townsquare-root');
+            if (root) root.setAttribute('data-townsquare-theme', theme === 'dark' ? 'dark' : 'light');
+        }
+
         function setTheme(theme) {
             document.documentElement.setAttribute('data-theme', theme);
             localStorage.setItem('theme', theme);
             updateThemeIcon(theme);
+            syncTownSquareTheme(theme);
         }
-        
+
         // Initialize icon based on current theme
         const currentTheme = document.documentElement.getAttribute('data-theme');
         updateThemeIcon(currentTheme);
+        syncTownSquareTheme(currentTheme);
         
         // Toggle theme on button click
         themeToggle.addEventListener('click', function() {


### PR DESCRIPTION
Embed the TownSquare widget below the footer in the shared template so it appears on every templated page. Add the self-contained theming CSS and wire the widget's data-townsquare-theme to the existing dark-mode toggle so it follows the site theme.