### PR TITLE
Fix TownSquare widget render-blocking and accent leak

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -427,3 +427,10 @@ img {
 #townsquare-root#townsquare-root .townsquare__ground {
   background: var(--ground);
 }
+
+/* TownSquare's tokens.css declares `:root { --accent: var(--you) }` (terracotta) and
+   loads after this stylesheet, so on equal specificity it would win the cascade and
+   recolor every link/nav/accent orange. Reassert the brand blue at higher specificity
+   (html:root beats a bare :root) so it always wins regardless of load order. */
+html:root { --accent: #0069ff; }
+html:root[data-theme="dark"] { --accent: #4a9eff; }

--- a/static/templates/template.html
+++ b/static/templates/template.html
@@ -49,7 +49,11 @@
         <footer>©️ {{year}} {{site_name}}</footer>
 
         <!-- TownSquare presence widget -->
-        <link rel="stylesheet" href="https://townsquare.cauenapier.com/widget.css" />
+        <!-- Load the third-party stylesheet non-render-blocking so it never delays
+             the rest of the page (e.g. the bio box that follows it in the DOM).
+             media="print" makes it inapplicable to screen until it has loaded,
+             then onload flips it to all. -->
+        <link rel="stylesheet" href="https://townsquare.cauenapier.com/widget.css" media="print" onload="this.media='all'">
         <div id="townsquare-root"></div>
         <script type="module">
           import { mountTownSquare } from "https://townsquare.cauenapier.com/townsquare.mjs";


### PR DESCRIPTION
The TownSquare embed introduced two regressions on every page:

- Its stylesheet was a render-blocking <link> in the middle of the document, ahead of the bio box, so that box stalled until the third-party widget.css -> tokens.css -> Google Fonts waterfall loaded. Load it non-render-blocking via media="print" onload swap.
- tokens.css declares `:root { --accent: var(--you) }` (terracotta) and loads after style.css, overriding the site's --accent and turning every link/nav/accent orange. Reassert the brand blue at higher specificity (html:root) so it wins regardless of load order.