### PR TITLE
feat: add rel=me to GitHub link for IndieWeb webring RelMeAuth

### DIFF
--- a/static/templates/template.html
+++ b/static/templates/template.html
@@ -76,7 +76,7 @@
             <a href="{{bio.social.linkedin.url}}" class="social-link" target="_blank" rel="noopener noreferrer">
                 <img src="{{bio.social.linkedin.icon}}" alt="LinkedIn" class="social-icon">
             </a>
-            <a href="{{bio.social.github.url}}" class="social-link" target="_blank" rel="noopener noreferrer">
+            <a href="{{bio.social.github.url}}" class="social-link" target="_blank" rel="me noopener noreferrer">
                 <img src="{{bio.social.github.icon}}" alt="GitHub" class="social-icon">
             </a>
             <a href="{{bio.social.rss.url}}" class="social-link" rel="noopener noreferrer">


### PR DESCRIPTION
Enables signing in to the IndieWeb webring (xn--sr8hvo.ws) by proving domain ownership via RelMeAuth: the homepage now advertises the GitHub profile as a verified identity. Requires the GitHub profile's website field to point back to emilesilvis.com to complete the two-way link.