### PR TITLE
Add call-to-action link to AI bubble article

### DIFF
--- a/posts/24-06-2026-maybe-is-ai-a-bubble-is-the-wrong-question.md
+++ b/posts/24-06-2026-maybe-is-ai-a-bubble-is-the-wrong-question.md
@@ -69,3 +69,5 @@ Bull and bear mostly agree the technology is real. They disagree on the clocks.
 Where do I land? I'm on the bearish side for now, but I'm watching these three clocks.
 
 We may still get an AI revolution. Just not one that rewards today's investors.
+
+[What do you think?](https://x.com/emilesilvis/status/2069844973759905817)


### PR DESCRIPTION
## Summary
Added a call-to-action link at the end of the "Maybe 'Is AI a Bubble' is the Wrong Question" article to encourage reader engagement on social media.

## Changes
- Added a link to an X (Twitter) conversation thread at the end of the article, inviting readers to share their thoughts on the topic

## Details
The link directs to a specific X thread where the article author (@emilesilvis) is discussing the AI bubble question, creating an opportunity for readers to engage in the conversation and share their perspectives on whether the technology timeline or valuation concerns are the real issue.

https://claude.ai/code/session_01WEu341oYcmjjULnHjhfcWX