### PR TITLE
Add Projects page

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,6 +40,10 @@ NAVIGATION = [
         "path": "/"
     },
     {
+        "title": "Projects",
+        "path": "/projects"
+    },
+    {
         "title": "Books read",
         "path": "/books-read"
     },

--- a/pages/projects.md
+++ b/pages/projects.md
@@ -1,0 +1,7 @@
+# Projects
+
+A few things I've built and tinker with.
+
+- **[handwritten.blog](https://handwritten.blog)** — A blogging platform for handwritten posts: write on paper or a tablet, photograph your page, and publish it as a live web post — you can even draw clickable link boxes onto your handwriting.
+- **[SDD Observatory](https://sddobservatory.com)** — An open, community-maintained directory tracking spec-driven development frameworks and real-world projects over time, to evaluate how different approaches hold up in practice.
+- **[Wolf Tone](/wolftone)** — A string-theory puzzle game where you build the universe on a luthier's bench. In playtesting and headed to Steam — play the prototype in your browser.


### PR DESCRIPTION
Adds a Projects page with a short description and link for each project:

- **handwritten.blog** — external
- **SDD Observatory** (sddobservatory.com) — external
- **Wolf Tone** — internal link to `/wolftone` (served from `apps/wolftone/`, already on `main` via #32)

Also adds a "Projects" entry to the nav, after Posts.

Clean 2-file diff (`config.py`, `pages/projects.md`); merges without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)