### PR TITLE
Add Stripe verification page

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,10 +44,6 @@ NAVIGATION = [
         "path": "/projects"
     },
     {
-        "title": "Software business",
-        "path": "/emile-silvis-software"
-    },
-    {
         "title": "Books read",
         "path": "/books-read"
     },

--- a/config.py
+++ b/config.py
@@ -44,6 +44,10 @@ NAVIGATION = [
         "path": "/projects"
     },
     {
+        "title": "Software business",
+        "path": "/emile-silvis-software"
+    },
+    {
         "title": "Books read",
         "path": "/books-read"
     },

--- a/pages/emile-silvis-software.md
+++ b/pages/emile-silvis-software.md
@@ -1,0 +1,55 @@
+---
+seo_description: "Official business, product, payment, support, refund, and cancellation information for Emile Silvis Software."
+---
+# Emile Silvis Software
+
+Emile Silvis Software is the umbrella business through which Emile Silvis develops and operates independent software products. It is the business name registered with our payment provider, Stripe.
+
+If **Emile Silvis Software** or **EMILE SILVIS** appears on your receipt, card statement, or bank statement, it means a product operated by Emile Silvis Software used Stripe to process the payment. The product name may be different from the business name shown by your bank.
+
+## Products
+
+### [handwritten.blog](https://handwritten.blog/)
+
+handwritten.blog is a hosted publishing service that turns handwritten pages into a blog. Authors can upload images or PDFs of their handwriting, add transcripts and links, and publish the pages on a handwritten.blog address.
+
+- **Product page:** [handwritten.blog](https://handwritten.blog/)
+- **Start using it:** [Create a handwritten.blog account](https://handwritten.blog/registration/new)
+- **Terms and restrictions:** [Terms of use](https://handwritten.blog/terms) and [privacy notice](https://handwritten.blog/privacy)
+- **Current price:** Free
+
+handwritten.blog does not currently offer a paid plan, paid subscription, or active checkout. Its core features are free to use. If paid features are introduced, their price and payment terms will be shown before checkout and this page will be updated before payments are accepted.
+
+No other products are currently sold through this Stripe account. Other projects associated with Emile Silvis are not covered by this business page unless they are explicitly listed here.
+
+## Customer support
+
+For questions about handwritten.blog, an expected payment, or a charge you do not recognise:
+
+- Email [hello@handwritten.blog](mailto:hello@handwritten.blog)
+- Phone [+31 6 14650482](tel:+31614650482)
+
+Please include the product name, charge date and charge amount when asking about a payment. Do not send full card or bank-account details by email.
+
+## Refunds and payment disputes
+
+There are no paid products at present, so Emile Silvis Software does not currently collect product payments and there is no purchase to refund.
+
+If you see a charge labelled **Emile Silvis Software** or **EMILE SILVIS** that you do not recognise, contact us using the details above so we can investigate. If you believe a payment was unauthorised, you may also contact your bank or card issuer. This does not limit any rights available to you under applicable law.
+
+Any future paid product will state its price, refund conditions and other payment terms before checkout. Those product-specific terms will also be linked from this page.
+
+## Subscription cancellation
+
+There are no paid subscriptions at present, so there is currently no subscription to cancel. Before any subscription is offered, its checkout will explain the billing period, renewal terms, how to cancel, when cancellation takes effect, and whether any refund applies. This page will be updated with the same information.
+
+Free handwritten.blog accounts and blogs can be deleted at any time from the service settings, as described in the [handwritten.blog terms](https://handwritten.blog/terms).
+
+## Business details
+
+- **Business name:** Emile Silvis Software
+- **Operator:** Emile Silvis, Netherlands
+- **Payment processor:** Stripe
+- **Statement descriptor:** EMILE SILVIS
+
+Last updated: 9 August 2026.

--- a/pages/emile-silvis-software.md
+++ b/pages/emile-silvis-software.md
@@ -3,47 +3,51 @@ seo_description: "Official business, product, payment, support, refund, and canc
 ---
 # Emile Silvis Software
 
-Emile Silvis Software is the umbrella business through which Emile Silvis develops and operates independent software products. It is the business name registered with our payment provider, Stripe.
+Emile Silvis Software is the umbrella business I use to develop and operate my independent software products. It is the business name registered with my payment provider, Stripe.
 
-If **Emile Silvis Software** or **EMILE SILVIS** appears on your receipt, card statement, or bank statement, it means a product operated by Emile Silvis Software used Stripe to process the payment. The product name may be different from the business name shown by your bank.
+If **Emile Silvis Software** or **EMILE SILVIS** appears on your receipt, card statement, or bank statement, it means you bought a product I operate through this business. The product name may be different from the business name shown by your bank.
 
 ## Products
 
 ### [handwritten.blog](https://handwritten.blog/)
 
-handwritten.blog is a hosted publishing service that turns handwritten pages into a blog. Authors can upload images or PDFs of their handwriting, add transcripts and links, and publish the pages on a handwritten.blog address.
+handwritten.blog is a hosted publishing service I am building to turn handwritten pages into a blog. You can upload images or PDFs of your handwriting, add transcripts and links, and publish the pages on your own handwritten.blog address.
 
 - **Product page:** [handwritten.blog](https://handwritten.blog/)
 - **Start using it:** [Create a handwritten.blog account](https://handwritten.blog/registration/new)
 - **Terms and restrictions:** [Terms of use](https://handwritten.blog/terms) and [privacy notice](https://handwritten.blog/privacy)
 - **Current price:** Free
 
-handwritten.blog does not currently offer a paid plan, paid subscription, or active checkout. Its core features are free to use. If paid features are introduced, their price and payment terms will be shown before checkout and this page will be updated before payments are accepted.
+handwritten.blog does not currently offer a paid plan, paid subscription, or active checkout. Its core features are free to use.
 
-No other products are currently sold through this Stripe account. Other projects associated with Emile Silvis are not covered by this business page unless they are explicitly listed here.
+If I introduce paid features, I will show you the price and payment terms before checkout. I will also update this page before I accept any payments.
+
+I do not currently sell any other products through this Stripe account. My other projects are not covered by this business page unless I explicitly list them here.
 
 ## Customer support
 
-For questions about handwritten.blog, an expected payment, or a charge you do not recognise:
+If you have a question about handwritten.blog, an expected payment, or a charge you do not recognise, you can contact me here:
 
 - Email [hello@handwritten.blog](mailto:hello@handwritten.blog)
 - Phone [+31 6 14650482](tel:+31614650482)
 
-Please include the product name, charge date and charge amount when asking about a payment. Do not send full card or bank-account details by email.
+Please include the product name, charge date, and charge amount when asking about a payment. Do not send me your full card or bank-account details by email.
 
 ## Refunds and payment disputes
 
-There are no paid products at present, so Emile Silvis Software does not currently collect product payments and there is no purchase to refund.
+I do not currently collect product payments, so there is no purchase to refund.
 
-If you see a charge labelled **Emile Silvis Software** or **EMILE SILVIS** that you do not recognise, contact us using the details above so we can investigate. If you believe a payment was unauthorised, you may also contact your bank or card issuer. This does not limit any rights available to you under applicable law.
+If you see a charge labelled **Emile Silvis Software** or **EMILE SILVIS** that you do not recognise, contact me using the details above. I will investigate it. If you believe the payment was unauthorised, you can also contact your bank or card issuer. This does not limit any rights available to you under applicable law.
 
-Any future paid product will state its price, refund conditions and other payment terms before checkout. Those product-specific terms will also be linked from this page.
+Before I sell a paid product, I will state its price, refund conditions, and other payment terms at checkout. I will also link its product-specific terms from this page.
 
 ## Subscription cancellation
 
-There are no paid subscriptions at present, so there is currently no subscription to cancel. Before any subscription is offered, its checkout will explain the billing period, renewal terms, how to cancel, when cancellation takes effect, and whether any refund applies. This page will be updated with the same information.
+I do not currently sell paid subscriptions, so there is no subscription to cancel.
 
-Free handwritten.blog accounts and blogs can be deleted at any time from the service settings, as described in the [handwritten.blog terms](https://handwritten.blog/terms).
+Before I offer a subscription, I will explain the billing period, renewal terms, how to cancel, when cancellation takes effect, and whether any refund applies. I will put that information at checkout and update this page with the same details.
+
+You can delete a free handwritten.blog account or blog at any time from the service settings, as described in the [handwritten.blog terms](https://handwritten.blog/terms).
 
 ## Business details
 


### PR DESCRIPTION
## What changed

- add a public Emile Silvis Software business and payment-information page
- list handwritten.blog as the first intended product and clearly state that it is currently free
- document customer support, payment-dispute, refund, and subscription-cancellation information
- explain the Emile Silvis Software / EMILE SILVIS statement name
- link the page from the site navigation and include it in the generated sitemap

## Why

Stripe account activation requires a public website that accurately describes the umbrella business, its products, customer support, and payment policies. The Stripe product catalog currently contains no paid products, so the page avoids claiming that unrelated projects or nonexistent paid plans are sold through the account.

## Validation

- built successfully with `python build.py`
- verified generated HTML and sitemap entry
- visually checked the full page at desktop and mobile widths
- confirmed the handwritten.blog product, signup, terms, and privacy links return successfully
- confirmed the existing GitHub Pages host serves `.html` pages through extensionless HTTPS routes