### PR TITLE
Add Pangram human-writing badges

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m unittest discover -s tests -v
+
+      - name: Restore Pangram analysis cache
+        uses: actions/cache@v4
+        with:
+          path: .cache/pangram
+          key: pangram-default-v1-${{ runner.os }}-${{ hashFiles('posts/*.md', 'pangram_badge.py') }}
+          restore-keys: |
+            pangram-default-v1-${{ runner.os }}-
       
       - name: Build site
         run: python build.py
+        env:
+          PANGRAM_API_KEY: ${{ secrets.PANGRAM_API_KEY }}
+          PANGRAM_CACHE_PATH: .cache/pangram/results.json
+          PANGRAM_MODEL: default
+          PANGRAM_REQUIRED: "true"
       
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -41,6 +57,7 @@ jobs:
           path: ./out
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -49,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.cache/
 out/
 __pycache__/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@ Minimalist static site generator.
 To build:
 `python build.py`
 
+Posts are checked by Pangram at build time. When Pangram classifies a post as
+`Human`, the generated page includes a "Verified human writing" badge linking
+to Pangram's public analysis. Set the API key in the environment; it is never
+included in the generated site:
+
+`export PANGRAM_API_KEY=<your API key>`
+
+Results are cached in `.cache/pangram`, keyed by the post content, so unchanged
+posts are not charged or submitted again. The GitHub Pages workflow expects the
+same key in the `PANGRAM_API_KEY` Actions secret.
+
 To serve:
 `npx serve out`
 

--- a/build.py
+++ b/build.py
@@ -4,6 +4,11 @@ from pathlib import Path
 from datetime import datetime
 import shutil, re, html, hashlib
 import markdown  # only external dependency
+from pangram_badge import (
+    PangramBadgeService,
+    prose_from_html,
+    verified_human_badge,
+)
 
 
 ROOT = Path(__file__).parent
@@ -94,7 +99,7 @@ def apply_template(title, body_html, seo_image="", seo_description="", date="", 
             .replace("{{umami_website_id}}", UMAMI["website_id"]))
 
 
-def build_post(md_path, is_page=False):
+def build_post(md_path, is_page=False, pangram_badges=None):
     raw = md_path.read_text(encoding="utf-8")
     
     # Parse frontmatter if it exists
@@ -125,11 +130,28 @@ def build_post(md_path, is_page=False):
     else:
         date = frontmatter.get("date", "-".join(md_path.stem.split("-", 3)[:3]))
         main_heading = f'<h1>{html.escape(title)}</h1>\n<time datetime="{date}" class="post-date">{date}</time>'
+
+        if pangram_badges is not None:
+            result = pangram_badges.analyze(prose_from_html(html_body))
+            if result is not None:
+                badge_html = verified_human_badge(result)
+                if badge_html:
+                    html_body = f"{html_body}\n{badge_html}"
+                    print(f"Pangram: verified {md_path.name} as human-written")
+                else:
+                    print(
+                        f"Pangram: {md_path.name} classified as "
+                        f"{result.prediction_short}; badge omitted"
+                    )
     
     return title, apply_template(title, html_body, seo_image=seo_image, seo_description=seo_description, date=date, main_heading=main_heading)
 
 
 def main():
+    pangram_badges = PangramBadgeService.from_environment(
+        ROOT / ".cache" / "pangram" / "results.json"
+    )
+
     # clean & recreate output dir
     if OUT.exists(): shutil.rmtree(OUT)
     OUT.mkdir()
@@ -159,7 +181,11 @@ def main():
     # Process pages
     pages = sorted(PAGES.glob("*.md"))
     for md in pages:
-        title, full_html = build_post(md, is_page=True)
+        title, full_html = build_post(
+            md,
+            is_page=True,
+            pangram_badges=pangram_badges,
+        )
         slug = md.stem
         fname = f"{slug}.html"
         (OUT / fname).write_text(full_html, encoding="utf-8")
@@ -173,7 +199,7 @@ def main():
     posts_by_year = {}
 
     for md in posts:
-        title, full_html = build_post(md)
+        title, full_html = build_post(md, pangram_badges=pangram_badges)
         slug = md.stem.split("-", 3)[-1]  # after the date
         fname = f"{slug}.html"
         (OUT / fname).write_text(full_html, encoding="utf-8")

--- a/build.py
+++ b/build.py
@@ -143,6 +143,7 @@ def build_post(md_path, is_page=False, pangram_badges=None):
                         f"Pangram: {md_path.name} classified as "
                         f"{result.prediction_short}; badge omitted"
                     )
+                print(f"Pangram report: {md_path.name} {result.dashboard_link}")
     
     return title, apply_template(title, html_body, seo_image=seo_image, seo_description=seo_description, date=date, main_heading=main_heading)
 

--- a/pangram_badge.py
+++ b/pangram_badge.py
@@ -1,0 +1,380 @@
+"""Build-time Pangram analysis and verified-human badge rendering.
+
+Only compact result metadata is cached. The submitted post text and API key are
+never written to the cache or generated site.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+from html import escape
+from html.parser import HTMLParser
+import json
+import os
+from pathlib import Path
+import tempfile
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
+
+
+API_BASE_URL = "https://text.external-api.pangram.com"
+CACHE_SCHEMA_VERSION = 1
+DEFAULT_MODEL = "default"
+TERMINAL_SUCCESS = "STAGE_SUCCESS"
+TERMINAL_FAILURE = "STAGE_FAILED"
+
+
+class PangramError(RuntimeError):
+    """Raised when Pangram cannot produce a trustworthy completed result."""
+
+
+@dataclass(frozen=True)
+class PangramResult:
+    model: str
+    version: str
+    headline: str
+    prediction_short: str
+    fraction_ai: float
+    fraction_ai_assisted: float
+    fraction_human: float
+    dashboard_link: str
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, Any], *, model: str) -> "PangramResult":
+        try:
+            result = cls(
+                model=model,
+                version=_required_string(value, "version"),
+                headline=_required_string(value, "headline"),
+                prediction_short=_required_string(value, "prediction_short"),
+                fraction_ai=_fraction(value, "fraction_ai"),
+                fraction_ai_assisted=_fraction(value, "fraction_ai_assisted"),
+                fraction_human=_fraction(value, "fraction_human"),
+                dashboard_link=_required_string(value, "dashboard_link"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise PangramError(f"Pangram returned an invalid result: {exc}") from exc
+
+        if not _is_pangram_dashboard_url(result.dashboard_link):
+            raise PangramError("Pangram did not return a valid public dashboard link")
+        return result
+
+    def to_cache(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @property
+    def is_verified_human(self) -> bool:
+        return self.prediction_short.casefold() == "human"
+
+
+def _required_string(value: dict[str, Any], key: str) -> str:
+    result = value.get(key)
+    if not isinstance(result, str) or not result.strip():
+        raise ValueError(f"{key} is missing")
+    return result.strip()
+
+
+def _fraction(value: dict[str, Any], key: str) -> float:
+    result = value.get(key)
+    if isinstance(result, bool) or not isinstance(result, (int, float)):
+        raise ValueError(f"{key} is not a number")
+    result = float(result)
+    if not 0.0 <= result <= 1.0:
+        raise ValueError(f"{key} is outside the 0–1 range")
+    return result
+
+
+def _is_pangram_dashboard_url(value: str) -> bool:
+    parsed = urlparse(value)
+    hostname = (parsed.hostname or "").casefold()
+    return (
+        parsed.scheme == "https"
+        and (hostname == "pangram.com" or hostname.endswith(".pangram.com"))
+        and bool(parsed.path)
+    )
+
+
+class PangramClient:
+    """Small client for Pangram's asynchronous text-analysis API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        model: str = DEFAULT_MODEL,
+        base_url: str = API_BASE_URL,
+        timeout_seconds: float = 300,
+        poll_interval_seconds: float = 0.5,
+        request_timeout_seconds: float = 30,
+    ) -> None:
+        if not api_key.strip():
+            raise ValueError("api_key must not be empty")
+        if not model.strip():
+            raise ValueError("model must not be empty")
+        self.api_key = api_key
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self.request_timeout_seconds = request_timeout_seconds
+
+    def analyze(self, text: str) -> PangramResult:
+        created = self._request_json(
+            "POST",
+            "/task",
+            {
+                "text": text,
+                "model": self.model,
+                "public_dashboard_link": True,
+            },
+        )
+        task_id = created.get("task_id")
+        if not isinstance(task_id, str) or not task_id.strip():
+            raise PangramError("Pangram did not return a task ID")
+
+        deadline = time.monotonic() + self.timeout_seconds
+        while True:
+            response = self._request_json("GET", f"/task/{quote(task_id, safe='')}")
+            stage = response.get("stage")
+            if stage == TERMINAL_SUCCESS:
+                return PangramResult.from_mapping(response, model=self.model)
+            if stage == TERMINAL_FAILURE:
+                reason = response.get("headline") or "analysis failed"
+                raise PangramError(f"Pangram analysis failed: {reason}")
+            if time.monotonic() >= deadline:
+                raise PangramError(
+                    f"Pangram analysis did not finish within {self.timeout_seconds:g} seconds"
+                )
+            time.sleep(self.poll_interval_seconds)
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        body = None
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "emilesilvis.com-build/1.0",
+            "x-api-key": self.api_key,
+        }
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urlopen(request, timeout=self.request_timeout_seconds) as response:
+                raw = response.read()
+        except HTTPError as exc:
+            detail = _response_detail(exc.read())
+            suffix = f": {detail}" if detail else ""
+            raise PangramError(f"Pangram returned HTTP {exc.code}{suffix}") from None
+        except URLError as exc:
+            raise PangramError(f"Could not reach Pangram: {exc.reason}") from None
+
+        try:
+            value = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise PangramError("Pangram returned malformed JSON") from exc
+        if not isinstance(value, dict):
+            raise PangramError("Pangram returned an unexpected response")
+        return value
+
+
+def _response_detail(raw: bytes) -> str:
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return ""
+    if not isinstance(value, dict):
+        return ""
+    detail = value.get("detail") or value.get("message") or value.get("error")
+    return str(detail)[:240] if detail else ""
+
+
+class PangramBadgeService:
+    """Resolve Pangram results from a content-addressed cache or the API."""
+
+    def __init__(
+        self,
+        cache_path: Path,
+        *,
+        model: str = DEFAULT_MODEL,
+        api_key: str | None = None,
+        required: bool = False,
+        client: PangramClient | None = None,
+    ) -> None:
+        self.cache_path = cache_path
+        self.model = model
+        self.required = required
+        self.client = client or (
+            PangramClient(api_key, model=model) if api_key and api_key.strip() else None
+        )
+        self.entries = self._load_entries()
+
+    @classmethod
+    def from_environment(cls, default_cache_path: Path) -> "PangramBadgeService":
+        cache_path = Path(os.environ.get("PANGRAM_CACHE_PATH", default_cache_path))
+        return cls(
+            cache_path,
+            model=os.environ.get("PANGRAM_MODEL", DEFAULT_MODEL),
+            api_key=os.environ.get("PANGRAM_API_KEY"),
+            required=_environment_flag("PANGRAM_REQUIRED"),
+        )
+
+    def analyze(self, text: str) -> PangramResult | None:
+        normalized = text.strip()
+        if not normalized:
+            return None
+
+        fingerprint = self._fingerprint(normalized)
+        cached = self.entries.get(fingerprint)
+        if isinstance(cached, dict):
+            try:
+                return PangramResult.from_mapping(cached, model=self.model)
+            except PangramError:
+                # A malformed or old cache entry should be refreshed when possible.
+                self.entries.pop(fingerprint, None)
+
+        if self.client is None:
+            if self.required:
+                raise PangramError(
+                    "This post has no cached Pangram result and PANGRAM_API_KEY is not set"
+                )
+            return None
+
+        result = self.client.analyze(normalized)
+        self.entries[fingerprint] = result.to_cache()
+        self._save_entries()
+        return result
+
+    def _fingerprint(self, text: str) -> str:
+        payload = f"{CACHE_SCHEMA_VERSION}\0{self.model}\0{text}".encode("utf-8")
+        return sha256(payload).hexdigest()
+
+    def _load_entries(self) -> dict[str, dict[str, Any]]:
+        try:
+            value = json.loads(self.cache_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {}
+        if not isinstance(value, dict) or value.get("schema_version") != CACHE_SCHEMA_VERSION:
+            return {}
+        entries = value.get("entries")
+        return entries if isinstance(entries, dict) else {}
+
+    def _save_entries(self) -> None:
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        value = {
+            "schema_version": CACHE_SCHEMA_VERSION,
+            "entries": self.entries,
+        }
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=self.cache_path.parent,
+            prefix=f".{self.cache_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            temporary_path = Path(handle.name)
+        temporary_path.replace(self.cache_path)
+
+
+def _environment_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().casefold() in {"1", "true", "yes", "on"}
+
+
+class _ProseExtractor(HTMLParser):
+    skipped_tags = {"code", "pre", "script", "style", "svg", "video"}
+    block_tags = {
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "br",
+        "dd",
+        "div",
+        "dl",
+        "dt",
+        "figcaption",
+        "figure",
+        "footer",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hr",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "section",
+        "table",
+        "td",
+        "th",
+        "tr",
+        "ul",
+    }
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self.skip_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in self.skipped_tags:
+            self.skip_depth += 1
+        elif not self.skip_depth and tag in self.block_tags:
+            self.parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in self.skipped_tags:
+            self.skip_depth = max(0, self.skip_depth - 1)
+        elif not self.skip_depth and tag in self.block_tags:
+            self.parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if not self.skip_depth:
+            self.parts.append(data)
+
+
+def prose_from_html(html_content: str) -> str:
+    """Extract readable prose while excluding code and embedded media."""
+
+    parser = _ProseExtractor()
+    parser.feed(html_content)
+    parser.close()
+    lines = [" ".join(line.split()) for line in "".join(parser.parts).splitlines()]
+    return "\n\n".join(line for line in lines if line)
+
+
+def verified_human_badge(result: PangramResult) -> str:
+    """Render a badge only for Pangram's categorical Human result."""
+
+    if not result.is_verified_human:
+        return ""
+
+    dashboard_link = escape(result.dashboard_link, quote=True)
+    return f'''<aside class="pangram-verification" aria-label="Verified human writing by Pangram">
+  <a class="pangram-verification__link" href="{dashboard_link}" target="_blank" rel="noopener noreferrer" title="Open this post's public Pangram analysis">
+    <span class="pangram-verification__check" aria-hidden="true">✓</span>
+    <strong>Verified human writing</strong> by <span class="pangram-verification__source">Pangram</span>
+  </a>
+</aside>'''

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -293,6 +293,32 @@ th {
     text-decoration: underline;
 }
 
+/* Pangram human-writing verification */
+.pangram-verification {
+    margin: 3rem 0 0;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.pangram-verification__link {
+    color: var(--text-muted);
+}
+
+.pangram-verification__check {
+    margin-right: 0.2rem;
+    color: var(--text-color);
+}
+
+.pangram-verification strong {
+    color: var(--text-color);
+}
+
+.pangram-verification__source {
+    color: var(--accent);
+}
+
 /* Footer */
 footer {
     margin-top: 3rem;

--- a/tests/test_pangram_badge.py
+++ b/tests/test_pangram_badge.py
@@ -1,3 +1,5 @@
+import io
+from contextlib import redirect_stdout
 import json
 from pathlib import Path
 import tempfile
@@ -164,10 +166,17 @@ class PangramRenderingTests(unittest.TestCase):
                 client=client,
             )
 
-            _, generated_html = build_post(post_path, pangram_badges=service)
+            output = io.StringIO()
+            with redirect_stdout(output):
+                _, generated_html = build_post(post_path, pangram_badges=service)
 
             self.assertIn("Verified human writing", generated_html)
             self.assertEqual(client.calls, ["A paragraph written by a person."])
+            self.assertIn(
+                "Pangram report: 01-01-2026-test-post.md "
+                "https://www.pangram.com/history/result-123",
+                output.getvalue(),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_pangram_badge.py
+++ b/tests/test_pangram_badge.py
@@ -1,0 +1,174 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from build import build_post
+from pangram_badge import (
+    PangramBadgeService,
+    PangramClient,
+    PangramError,
+    PangramResult,
+    prose_from_html,
+    verified_human_badge,
+)
+
+
+def pangram_result(*, prediction_short="Human", fraction_human=0.97):
+    return PangramResult(
+        model="default",
+        version="4.0",
+        headline="Human Written",
+        prediction_short=prediction_short,
+        fraction_ai=0.01,
+        fraction_ai_assisted=0.02,
+        fraction_human=fraction_human,
+        dashboard_link="https://www.pangram.com/history/result-123",
+    )
+
+
+class StubPangramClient:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def analyze(self, text):
+        self.calls.append(text)
+        return self.result
+
+
+class PangramClientTests(unittest.TestCase):
+    def test_async_request_uses_explicit_model_and_public_dashboard(self):
+        class Client(PangramClient):
+            def __init__(self):
+                super().__init__("secret", model="pangram-4")
+                self.calls = []
+
+            def _request_json(self, method, path, payload=None):
+                self.calls.append((method, path, payload))
+                if method == "POST":
+                    return {"task_id": "task-123"}
+                return {
+                    "stage": "STAGE_SUCCESS",
+                    "version": "4.0",
+                    "headline": "Human Written",
+                    "prediction_short": "Human",
+                    "fraction_ai": 0.0,
+                    "fraction_ai_assisted": 0.03,
+                    "fraction_human": 0.97,
+                    "dashboard_link": "https://www.pangram.com/history/result-123",
+                }
+
+        client = Client()
+        result = client.analyze("Some prose")
+
+        self.assertTrue(result.is_verified_human)
+        self.assertEqual(
+            client.calls[0],
+            (
+                "POST",
+                "/task",
+                {
+                    "text": "Some prose",
+                    "model": "pangram-4",
+                    "public_dashboard_link": True,
+                },
+            ),
+        )
+        self.assertEqual(client.calls[1], ("GET", "/task/task-123", None))
+
+    def test_failed_task_is_an_error(self):
+        class Client(PangramClient):
+            def _request_json(self, method, path, payload=None):
+                if method == "POST":
+                    return {"task_id": "task-123"}
+                return {"stage": "STAGE_FAILED", "headline": "No valid text"}
+
+        with self.assertRaisesRegex(PangramError, "No valid text"):
+            Client("secret").analyze("Some prose")
+
+
+class PangramCacheTests(unittest.TestCase):
+    def test_cache_avoids_repeat_api_calls_and_does_not_store_post_text(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache_path = Path(directory) / "pangram" / "results.json"
+            client = StubPangramClient(pangram_result())
+            service = PangramBadgeService(cache_path, client=client, required=True)
+
+            first = service.analyze("Words that should never be stored in the cache")
+            cached_service = PangramBadgeService(cache_path, required=True)
+            second = cached_service.analyze(
+                "Words that should never be stored in the cache"
+            )
+
+            self.assertEqual(first, second)
+            self.assertEqual(len(client.calls), 1)
+            cache_contents = cache_path.read_text(encoding="utf-8")
+            self.assertNotIn("Words that should never", cache_contents)
+            self.assertNotIn("secret", cache_contents)
+            self.assertEqual(json.loads(cache_contents)["schema_version"], 1)
+
+    def test_required_result_without_cache_or_key_is_an_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            service = PangramBadgeService(
+                Path(directory) / "results.json",
+                required=True,
+            )
+            with self.assertRaisesRegex(PangramError, "PANGRAM_API_KEY"):
+                service.analyze("An uncached post")
+
+
+class PangramRenderingTests(unittest.TestCase):
+    def test_prose_extraction_omits_code_and_embedded_media(self):
+        content = """
+        <p>Hello <a href="https://example.com">world</a>.</p>
+        <pre><code>do_not_scan()</code></pre>
+        <p>After &amp; later.</p>
+        <video>video fallback text</video>
+        """
+        self.assertEqual(prose_from_html(content), "Hello world.\n\nAfter & later.")
+
+    def test_badge_is_rendered_for_human_result(self):
+        badge = verified_human_badge(pangram_result(fraction_human=0.974))
+
+        self.assertIn("Verified human writing", badge)
+        self.assertIn(
+            'class="pangram-verification__link" href="https://www.pangram.com/history/result-123"',
+            badge,
+        )
+        self.assertNotIn("automated analysis", badge)
+
+    def test_badge_is_omitted_for_mixed_result(self):
+        self.assertEqual(
+            verified_human_badge(pangram_result(prediction_short="Mixed")),
+            "",
+        )
+
+    def test_non_pangram_dashboard_link_is_rejected(self):
+        value = pangram_result().to_cache()
+        value["dashboard_link"] = "https://pangram.example/history/fake"
+
+        with self.assertRaisesRegex(PangramError, "dashboard link"):
+            PangramResult.from_mapping(value, model="default")
+
+    def test_post_build_includes_badge_and_excludes_code_from_api_text(self):
+        with tempfile.TemporaryDirectory() as directory:
+            post_path = Path(directory) / "01-01-2026-test-post.md"
+            post_path.write_text(
+                "# A human post\n\nA paragraph written by a person.\n\n```python\nsecret_code()\n```\n",
+                encoding="utf-8",
+            )
+            client = StubPangramClient(pangram_result())
+            service = PangramBadgeService(
+                Path(directory) / "cache.json",
+                client=client,
+            )
+
+            _, generated_html = build_post(post_path, pangram_badges=service)
+
+            self.assertIn("Verified human writing", generated_html)
+            self.assertEqual(client.calls, ["A paragraph written by a person."])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #35

## What changed

- analyse each post's prose with Pangram during the static-site build
- cache compact results by content hash so unchanged posts are not rescanned
- show a bare-bones, clickable “Verified human writing by Pangram” badge only for Pangram's categorical `Human` result
- link each badge to that post's public Pangram report
- keep the API key in GitHub Actions and skip deployment for non-`main` workflow runs
- cover API polling, caching, prose extraction, validation, and badge rendering with unit tests

## Why

The badge gives readers an independently generated authorship signal without exposing the Pangram API key in this static site. Mixed or AI-classified writing never receives a human-verification claim.

## Mixed articles to rewrite

The live Pangram run classified 17 posts as `Human` and the following five as `Mixed`. These intentionally receive no badge until their content changes and a fresh scan classifies them as `Human`.

- [ ] [Maybe “is AI a bubble?” is the wrong question](https://emilesilvis.com/maybe-is-ai-a-bubble-is-the-wrong-question.html) — [Pangram report](https://www.pangram.com/history/ce25376a-a2de-4922-8c30-eb141132494a) — `posts/24-06-2026-maybe-is-ai-a-bubble-is-the-wrong-question.md`
- [ ] [How a list of 1s and 0s becomes tiny, physical switches (part 2/5)](https://emilesilvis.com/part-2-how-1-plus-1-becomes-a-list-of-1s-and-0s.html) — [Pangram report](https://www.pangram.com/history/41e4aa6e-f65d-4c03-ad92-d03703876389) — `posts/07-06-2026-part-2-how-a-list-of-1s-and-0s-becomes-tiny-physical-switches.md`
- [ ] [How tiny, physical switches learn to remember (part 3/5)](https://emilesilvis.com/part-3-how-tiny-physical-switches-learn-to-remember.html) — [Pangram report](https://www.pangram.com/history/c92246e2-6c4e-4c0f-8e40-a438f993f546) — `posts/08-06-2026-part-3-how-tiny-physical-switches-learn-to-remember.md`
- [ ] [How tiny, physical switches learn to follow instructions (part 4/5)](https://emilesilvis.com/part-4-how-tiny-physical-switches-learn-to-follow-instructions.html) — [Pangram report](https://www.pangram.com/history/bc7b3cc3-9dbb-49f8-907a-6aa3e3d475d5) — `posts/09-06-2026-part-4-how-tiny-physical-switches-learn-to-follow-instructions.md`
- [ ] [How 1+1 becomes 2 (part 5/5)](https://emilesilvis.com/part-5-how-1-plus-1-becomes-2.html) — [Pangram report](https://www.pangram.com/history/ce29822b-4fee-4473-8f47-337dec479afa) — `posts/10-06-2026-part-5-how-1-plus-1-becomes-2.md`

## Validation

- `python -m unittest discover -s tests -v` — 9 tests passed
- [Live Pangram workflow run](https://github.com/emilesilvis/emilesilvis.github.io/actions/runs/31566892088/attempts/2) — build and artifact upload succeeded
- verified a generated per-post Pangram report URL returns HTTP 200
- branch workflow's deploy job was skipped; the live site was not changed
