### PR TITLE
Expand Projects page and remove Wolf Tone

### DIFF
--- a/pages/projects.md
+++ b/pages/projects.md
@@ -2,7 +2,15 @@
 
 A few things I've built and tinker with.
 
-- **[handwritten.blog](https://handwritten.blog)** — A blogging platform for handwritten posts: write on paper or a tablet, photograph your page, and publish it as a live web post — you can even draw clickable link boxes onto your handwriting.
+- **[handwritten.blog](https://handwritten.blog)** — A blogging platform for handwritten posts: write on paper or a tablet, photograph your page, and publish it as a live web post — you can even draw clickable link boxes onto your handwriting. Experimental [reMarkable](https://github.com/emilesilvis/handwritten-blog-remarkable-uploader) and [Supernote](https://github.com/emilesilvis/handwritten-blog-supernote-plugin) clients send notebooks to private drafts.
 - **[SDD Observatory](https://sddobservatory.com)** — An open, community-maintained directory tracking spec-driven development frameworks and real-world projects over time, to evaluate how different approaches hold up in practice.
-- **[Wolf Tone](/wolftone)** — A string-theory puzzle game where you build the universe on a luthier's bench. In playtesting and headed to Steam — play the prototype in your browser.
+- **[How I AI](https://howiai.directory)** — A directory of creators' personal AI policies, documenting their choices, boundaries, and responsibilities when using AI in their work.
+- **[Cake](https://github.com/emilesilvis/cake)** — A small system for choosing what to work on and turning projects into finishable outcomes, with agent skills that work across Trello and GitHub.
+- **Spookasem** — An autonomous scout for overlooked software opportunities, gathering public evidence and putting promising business ideas through a critical review. In development.
+- **[Lily](/lily/)** — A browser puzzle game where moving words rewrites the rules of a garden. Explore thirty gardens, gather blooms, and find a way home, with undo and progressive hints.
+- **[How to Design a Zachlike](/how-to-design-a-zachlike/)** — A guide to designing open-ended engineering puzzle games, from mechanics and systems to teaching, optimisation, and playtesting.
+- **[Geomake](/geomake/)** — A geometry puzzle generator with a small browser collection, progressive hints, answer checking, and worked solutions.
 - **[Unit Circle](/unit-circle.html)** — Visualise all six trigonometric functions by dragging a point around the circle.
+- **[EU jobs visualisation](/llm-exposure-eu-jobs-interactive.html)** — Explore employment in the Netherlands and Europe, with occupations sized by workforce and coloured by LLM-estimated exposure to AI.
+- **[Generative plotter art](https://github.com/emilesilvis/grasshopper)** — Code-generated drawings for an AxiDraw pen plotter, alongside experiments with [quadrilateral tilings](https://github.com/emilesilvis/quad_tiling), [triangle tilings](https://github.com/emilesilvis/triangle_tiling), and [triangulation](https://github.com/emilesilvis/triangulation).
+- **[Nand2Tetris](/i-built-a-computer.html)** — My journey through building a simulated computer, from logic gates through to an assembler, VM translator, compiler, and operating system.


### PR DESCRIPTION
Expand the Projects page with How I AI, Cake, Spookasem, Lily, How to Design a Zachlike, Geomake, the EU jobs visualisation, generative plotter art, and Nand2Tetris. Include the experimental reMarkable and Supernote clients under handwritten.blog and remove parked Wolf Tone.

Validation: the site build and `git diff --check` pass; all ten external links and the existing internal targets resolve. Lily points to `/lily/`, whose hosting assets are now on `main`; its public URL still returned 404 at verification.