### PR TITLE
Publish answer-gated geometry puzzles

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -2,7 +2,7 @@ These are checked-in static applications copied into the site by `build.py`.
 
 | App | Version retained here | Upstream provenance |
 | --- | --- | --- |
-| Geomake | Edition `7472b5f5c599085e`, fourteen puzzles | [emilesilvis/geomake](https://github.com/emilesilvis/geomake), commit `08028c1e09c04013b3f39a4431d21e5818a02de9`, seed 7; see [release PR #40](https://github.com/emilesilvis/emilesilvis.github.io/pull/40). Older help files remain for cached pages. |
+| Geomake | Edition `7472b5f5c599085e`, fourteen puzzles with sequential answer gates | [emilesilvis/geomake](https://github.com/emilesilvis/geomake), commit `d8a407b1607d0f47bd5b698a7700460a633917e2`, seed 7; the puzzle pack is unchanged from [release PR #40](https://github.com/emilesilvis/emilesilvis.github.io/pull/40). Older help files remain for cached pages. |
 | How to design a Zachlike | 1.1.0, dated 2026-08-08 | Authored HTML is maintained here; no upstream repository or export command was recorded. |
 | Lily | English/Dutch static release, thirty gardens | Private Lily source, commit `1d3d394652b194c02841bfb703eff95343a17641`; archive checksum and repeatable build instructions are in [README.md](../README.md#lily). |
 
@@ -13,6 +13,18 @@ When importing an update:
 3. Update `public_pages.json` for added or removed HTML and `pages/projects.md` for changes to the public portfolio.
 4. Run the README's generator, generated-site, and browser checks. Geomake checks exercise all fourteen bundled answer/hint/solution flows; the guide checks cover navigation and table access.
 5. Review the generated pages on desktop and mobile before publishing.
+
+Rebuild Geomake from its source repository with
+`.venv/bin/python -m geomake pilot --seed 7 --out out/daily-pilot` (an empty output
+folder), then `python3 reader/build.py`. Validate upstream with
+`node --test reader/tests/*.test.js` and
+`.venv/bin/python -m pytest tests/test_reader.py`.
+For this reader update, the edition identifier and help data match the published
+pack. Import the generated HTML, `app.js`, `answer.js`, `progress.js`, and
+`styles.css`; retain the published diagrams, older help files, shared
+`/static/js/theme.js`, Projects/theme navigation, and its `.app-nav` styles.
+The gate unlocks the next puzzle only after a correct check and remembers
+consecutive completion in browser storage.
 
 `how-to-design-a-zachlike/index.html` is the canonical guide. `guide.html` is a
 compatibility redirect. Keep its hash-preserving redirect when replacing exports.

--- a/apps/README.md
+++ b/apps/README.md
@@ -2,7 +2,7 @@ These are checked-in static applications copied into the site by `build.py`.
 
 | App | Version retained here | Upstream provenance |
 | --- | --- | --- |
-| Geomake | Edition `7472b5f5c599085e`, fourteen puzzles with sequential answer gates | [emilesilvis/geomake](https://github.com/emilesilvis/geomake), commit `d8a407b1607d0f47bd5b698a7700460a633917e2`, seed 7; the puzzle pack is unchanged from [release PR #40](https://github.com/emilesilvis/emilesilvis.github.io/pull/40). Older help files remain for cached pages. |
+| Geomake | Edition `7472b5f5c599085e`, fourteen puzzles with sequential answer gates | [emilesilvis/geomake](https://github.com/emilesilvis/geomake), commit `96b51e4c79fc7682a67fed79807a4e240632b75f`, seed 7; the puzzle pack is unchanged from [release PR #40](https://github.com/emilesilvis/emilesilvis.github.io/pull/40). Older help files remain for cached pages. |
 | How to design a Zachlike | 1.1.0, dated 2026-08-08 | Authored HTML is maintained here; no upstream repository or export command was recorded. |
 | Lily | English/Dutch static release, thirty gardens | Private Lily source, commit `1d3d394652b194c02841bfb703eff95343a17641`; archive checksum and repeatable build instructions are in [README.md](../README.md#lily). |
 

--- a/apps/geomake/app.js
+++ b/apps/geomake/app.js
@@ -1,20 +1,60 @@
-import { evaluateAnswer, matchesAnswer } from './answer.js?v=9d30678079ce';
+import { evaluateAnswer, matchesAnswer } from './answer.js?v=537314553dbd';
+import { createProgress } from './progress.js?v=537314553dbd';
 
 const page = document.querySelector('main');
+const day = Number(page.dataset.day);
+const total = Number(page.dataset.total);
+const progress = createProgress(page.dataset.edition, total);
+const puzzle = document.querySelector('#puzzle');
+const locked = document.querySelector('#locked');
+const resume = document.querySelector('#resume');
+const progressNote = document.querySelector('#progress');
+const puzzleLinks = document.querySelectorAll('[data-puzzle-day]');
 const answer = document.querySelector('#answer');
 const feedback = document.querySelector('#feedback');
 const hintButton = document.querySelector('#hint');
 const explainButton = document.querySelector('#explain');
 const hints = document.querySelector('#hints');
 const solution = document.querySelector('#solution');
-const storageKey = `geomake:${page.dataset.edition}:${page.dataset.day}:answer`;
 let hintCount = 0;
 let checking = false;
 
-try { answer.value = localStorage.getItem(storageKey) || ''; } catch { /* Optional convenience only. */ }
+function updateProgress() {
+  const completed = progress.completedThrough();
+  const available = Math.min(completed + 1, total);
+  puzzle.hidden = day > available;
+  locked.hidden = !puzzle.hidden;
+  for (const link of puzzleLinks) {
+    const target = Number(link.dataset.puzzleDay);
+    if (target <= available) {
+      link.setAttribute('href', link.dataset.href);
+      link.removeAttribute('aria-disabled');
+      link.removeAttribute('role');
+    } else {
+      link.removeAttribute('href');
+      link.setAttribute('role', 'link');
+      link.setAttribute('aria-disabled', 'true');
+    }
+    if (target === available) resume.setAttribute('href', link.dataset.href);
+  }
+  resume.textContent = `Puzzle ${available}`;
+  for (const state of document.querySelectorAll('[data-state-day]')) {
+    const target = Number(state.dataset.stateDay);
+    state.textContent = target <= completed ? ' · Solved' : target > available ? ' · Locked' : '';
+  }
+  progressNote.textContent = day <= completed
+    ? (day < total ? `Puzzle ${day + 1} is unlocked.` : `All ${total} puzzles solved.`)
+    : (day < total ? `Enter the correct answer to unlock Puzzle ${day + 1}.` : 'Solve this puzzle to complete the set.');
+}
+
+updateProgress();
+window.addEventListener('storage', updateProgress);
+window.addEventListener('pageshow', updateProgress);
+
+answer.value = progress.loadAnswer(day);
 answer.addEventListener('input', () => {
   feedback.hidden = true;
-  try { localStorage.setItem(storageKey, answer.value); } catch { /* Solving works without storage. */ }
+  progress.saveAnswer(day, answer.value);
 });
 
 function message(text) {
@@ -30,14 +70,22 @@ async function readHelp(file) {
 
 document.querySelector('#answer-form').addEventListener('submit', async event => {
   event.preventDefault();
-  if (checking) return;
+  if (checking || puzzle.hidden) return;
   const submitted = answer.value;
   checking = true;
   document.querySelector('#check').disabled = true;
   try {
     evaluateAnswer(submitted);
     const expected = await readHelp('check');
-    if (answer.value === submitted) message(matchesAnswer(submitted, expected) ? 'Correct.' : 'Not quite. Try again.');
+    if (answer.value !== submitted) return;
+    if (!matchesAnswer(submitted, expected)) {
+      message('Not quite. Try again.');
+    } else if (progress.markSolved(day)) {
+      updateProgress();
+      message('Correct.');
+    } else {
+      message('Correct, but your progress could not be saved. Allow browser storage and check again.');
+    }
   } catch (error) {
     if (answer.value === submitted) message(error instanceof Error ? error.message : 'Please try again.');
   } finally {

--- a/apps/geomake/app.js
+++ b/apps/geomake/app.js
@@ -1,5 +1,5 @@
-import { evaluateAnswer, matchesAnswer } from './answer.js?v=537314553dbd';
-import { createProgress } from './progress.js?v=537314553dbd';
+import { evaluateAnswer, matchesAnswer } from './answer.js?v=9f8e67d17ccf';
+import { createProgress } from './progress.js?v=9f8e67d17ccf';
 
 const page = document.querySelector('main');
 const day = Number(page.dataset.day);

--- a/apps/geomake/day-02.html
+++ b/apps/geomake/day-02.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 2</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-02.html
+++ b/apps/geomake/day-02.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 2</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="2" data-help="data/7472b5f5c599085e/day-02" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="2" data-total="14" data-help="data/7472b5f5c599085e/day-02" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="index.html" rel="prev">← Previous</a>
+      <a href="index.html" data-puzzle-day="1" data-href="index.html" rel="prev">← Previous</a>
       <h1>Puzzle 2</h1>
-      <a href="day-03.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Medium</p>
-    <p id="question">A circle is inscribed in a square of side 4 cm. Find the shaded area (inside the square, outside the circle).</p>
-    <img class="diagram" src="images/day-02.png" alt="A circle is inscribed in a square of side 4 cm. Find the shaded area (inside the square, outside the circle)." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Medium</p>
+      <p id="question">A circle is inscribed in a square of side 4 cm. Find the shaded area (inside the square, outside the circle).</p>
+      <img class="diagram" src="images/day-02.png" alt="A circle is inscribed in a square of side 4 cm. Find the shaded area (inside the square, outside the circle)." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 3.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html" aria-current="page">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html" aria-current="page">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-03.html
+++ b/apps/geomake/day-03.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 3</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-03.html
+++ b/apps/geomake/day-03.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 3</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="3" data-help="data/7472b5f5c599085e/day-03" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="3" data-total="14" data-help="data/7472b5f5c599085e/day-03" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-02.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html" rel="prev">← Previous</a>
       <h1>Puzzle 3</h1>
-      <a href="day-04.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">In a square of side 4 cm, a quarter circle of radius 2 cm is drawn at each corner. Find the shaded area in the middle.</p>
-    <img class="diagram" src="images/day-03.png" alt="In a square of side 4 cm, a quarter circle of radius 2 cm is drawn at each corner. Find the shaded area in the middle." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">In a square of side 4 cm, a quarter circle of radius 2 cm is drawn at each corner. Find the shaded area in the middle.</p>
+      <img class="diagram" src="images/day-03.png" alt="In a square of side 4 cm, a quarter circle of radius 2 cm is drawn at each corner. Find the shaded area in the middle." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 4.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html" aria-current="page">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html" aria-current="page">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-04.html
+++ b/apps/geomake/day-04.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 4</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-04.html
+++ b/apps/geomake/day-04.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 4</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="4" data-help="data/7472b5f5c599085e/day-04" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="4" data-total="14" data-help="data/7472b5f5c599085e/day-04" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-03.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html" rel="prev">← Previous</a>
       <h1>Puzzle 4</h1>
-      <a href="day-05.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Medium</p>
-    <p id="question">A square is inscribed in a circle of radius 7 cm. Find the shaded area (inside the circle, outside the square).</p>
-    <img class="diagram" src="images/day-04.png" alt="A square is inscribed in a circle of radius 7 cm. Find the shaded area (inside the circle, outside the square)." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Medium</p>
+      <p id="question">A square is inscribed in a circle of radius 7 cm. Find the shaded area (inside the circle, outside the square).</p>
+      <img class="diagram" src="images/day-04.png" alt="A square is inscribed in a circle of radius 7 cm. Find the shaded area (inside the circle, outside the square)." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 5.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html" aria-current="page">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html" aria-current="page">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-05.html
+++ b/apps/geomake/day-05.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 5</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="5" data-help="data/7472b5f5c599085e/day-05" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="5" data-total="14" data-help="data/7472b5f5c599085e/day-05" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-04.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html" rel="prev">← Previous</a>
       <h1>Puzzle 5</h1>
-      <a href="day-06.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">Inside a square of side 10 cm, two quarter-circle arcs of radius 10 cm are drawn, centered at opposite corners. Find the shaded leaf-shaped area between them.</p>
-    <img class="diagram" src="images/day-05.png" alt="Inside a square of side 10 cm, two quarter-circle arcs of radius 10 cm are drawn, centered at opposite corners. Find the shaded leaf-shaped area between them." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">Inside a square of side 10 cm, two quarter-circle arcs of radius 10 cm are drawn, centered at opposite corners. Find the shaded leaf-shaped area between them.</p>
+      <img class="diagram" src="images/day-05.png" alt="Inside a square of side 10 cm, two quarter-circle arcs of radius 10 cm are drawn, centered at opposite corners. Find the shaded leaf-shaped area between them." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 6.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html" aria-current="page">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html" aria-current="page">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-05.html
+++ b/apps/geomake/day-05.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 5</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-06.html
+++ b/apps/geomake/day-06.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 6</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="6" data-help="data/7472b5f5c599085e/day-06" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="6" data-total="14" data-help="data/7472b5f5c599085e/day-06" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-05.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html" rel="prev">← Previous</a>
       <h1>Puzzle 6</h1>
-      <a href="day-07.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">The two circles have the same center. The 14 cm segment has both endpoints on the outer circle and is tangent to the inner circle (it just touches it). Find the shaded area between the circles.</p>
-    <img class="diagram" src="images/day-06.png" alt="The two circles have the same center. The 14 cm segment has both endpoints on the outer circle and is tangent to the inner circle (it just touches it). Find the shaded area between the circles." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">The two circles have the same center. The 14 cm segment has both endpoints on the outer circle and is tangent to the inner circle (it just touches it). Find the shaded area between the circles.</p>
+      <img class="diagram" src="images/day-06.png" alt="The two circles have the same center. The 14 cm segment has both endpoints on the outer circle and is tangent to the inner circle (it just touches it). Find the shaded area between the circles." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 7.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html" aria-current="page">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html" aria-current="page">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-06.html
+++ b/apps/geomake/day-06.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 6</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-07.html
+++ b/apps/geomake/day-07.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 7</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="7" data-help="data/7472b5f5c599085e/day-07" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="7" data-total="14" data-help="data/7472b5f5c599085e/day-07" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-06.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html" rel="prev">← Previous</a>
       <h1>Puzzle 7</h1>
-      <a href="day-08.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">Both squares have side 10 cm. A corner of the tilted square lies exactly at the center of the other square. Find their shaded overlap area. The angle of rotation is not given.</p>
-    <img class="diagram" src="images/day-07.png" alt="Both squares have side 10 cm. A corner of the tilted square lies exactly at the center of the other square. Find their shaded overlap area. The angle of rotation is not given." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">Both squares have side 10 cm. A corner of the tilted square lies exactly at the center of the other square. Find their shaded overlap area. The angle of rotation is not given.</p>
+      <img class="diagram" src="images/day-07.png" alt="Both squares have side 10 cm. A corner of the tilted square lies exactly at the center of the other square. Find their shaded overlap area. The angle of rotation is not given." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 8.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html" aria-current="page">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html" aria-current="page">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-07.html
+++ b/apps/geomake/day-07.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 7</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-08.html
+++ b/apps/geomake/day-08.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 8</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="8" data-help="data/7472b5f5c599085e/day-08" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="8" data-total="14" data-help="data/7472b5f5c599085e/day-08" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-07.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html" rel="prev">← Previous</a>
       <h1>Puzzle 8</h1>
-      <a href="day-09.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">ABCD is a square. Points E, F, G and H lie on AB, BC, CD and DA, respectively, with AE:EB = BF:FC = CG:GD = DH:HA = 1:3. The inner square EFGH has area 160 cm². Find the total shaded area of the four corners.</p>
-    <img class="diagram" src="images/day-08.png" alt="ABCD is a square. Points E, F, G and H lie on AB, BC, CD and DA, respectively, with AE:EB = BF:FC = CG:GD = DH:HA = 1:3. The inner square EFGH has area 160 cm². Find the total shaded area of the four corners." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">ABCD is a square. Points E, F, G and H lie on AB, BC, CD and DA, respectively, with AE:EB = BF:FC = CG:GD = DH:HA = 1:3. The inner square EFGH has area 160 cm². Find the total shaded area of the four corners.</p>
+      <img class="diagram" src="images/day-08.png" alt="ABCD is a square. Points E, F, G and H lie on AB, BC, CD and DA, respectively, with AE:EB = BF:FC = CG:GD = DH:HA = 1:3. The inner square EFGH has area 160 cm². Find the total shaded area of the four corners." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 9.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html" aria-current="page">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html" aria-current="page">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-08.html
+++ b/apps/geomake/day-08.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 8</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-09.html
+++ b/apps/geomake/day-09.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 9</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-09.html
+++ b/apps/geomake/day-09.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 9</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="9" data-help="data/7472b5f5c599085e/day-09" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="9" data-total="14" data-help="data/7472b5f5c599085e/day-09" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-08.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html" rel="prev">← Previous</a>
       <h1>Puzzle 9</h1>
-      <a href="day-10.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">In trapezoid ABCD, AB is parallel to CD. Diagonals AC and BD meet at O. Triangle COD has area 18 cm² and triangle AOB has area 32 cm². Find the total shaded area of triangles AOD and BOC.</p>
-    <img class="diagram" src="images/day-09.png" alt="In trapezoid ABCD, AB is parallel to CD. Diagonals AC and BD meet at O. Triangle COD has area 18 cm² and triangle AOB has area 32 cm². Find the total shaded area of triangles AOD and BOC." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">In trapezoid ABCD, AB is parallel to CD. Diagonals AC and BD meet at O. Triangle COD has area 18 cm² and triangle AOB has area 32 cm². Find the total shaded area of triangles AOD and BOC.</p>
+      <img class="diagram" src="images/day-09.png" alt="In trapezoid ABCD, AB is parallel to CD. Diagonals AC and BD meet at O. Triangle COD has area 18 cm² and triangle AOB has area 32 cm². Find the total shaded area of triangles AOD and BOC." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 10.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html" aria-current="page">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html" aria-current="page">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-10.html
+++ b/apps/geomake/day-10.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 10</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-10.html
+++ b/apps/geomake/day-10.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 10</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="10" data-help="data/7472b5f5c599085e/day-10" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="10" data-total="14" data-help="data/7472b5f5c599085e/day-10" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-09.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html" rel="prev">← Previous</a>
       <h1>Puzzle 10</h1>
-      <a href="day-11.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">Triangle ABC has area 56 cm². D lies on BC with BD:DC = 3:1, and E is the midpoint of AC. Segments AD and BE meet at P. Find the shaded area of triangle ABP.</p>
-    <img class="diagram" src="images/day-10.png" alt="Triangle ABC has area 56 cm². D lies on BC with BD:DC = 3:1, and E is the midpoint of AC. Segments AD and BE meet at P. Find the shaded area of triangle ABP." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">Triangle ABC has area 56 cm². D lies on BC with BD:DC = 3:1, and E is the midpoint of AC. Segments AD and BE meet at P. Find the shaded area of triangle ABP.</p>
+      <img class="diagram" src="images/day-10.png" alt="Triangle ABC has area 56 cm². D lies on BC with BD:DC = 3:1, and E is the midpoint of AC. Segments AD and BE meet at P. Find the shaded area of triangle ABP." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 11.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html" aria-current="page">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html" aria-current="page">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-11.html
+++ b/apps/geomake/day-11.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 11</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-11.html
+++ b/apps/geomake/day-11.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 11</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="11" data-help="data/7472b5f5c599085e/day-11" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="11" data-total="14" data-help="data/7472b5f5c599085e/day-11" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-10.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html" rel="prev">← Previous</a>
       <h1>Puzzle 11</h1>
-      <a href="day-12.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">E is the midpoint of side AC of triangle ABC. D lies on BC, and AD meets BE at P. Triangle ABP has area 54 cm²; triangle APE has area 9 cm². The position of D is otherwise unknown. Find the shaded area of triangle BDP.</p>
-    <img class="diagram" src="images/day-11.png" alt="E is the midpoint of side AC of triangle ABC. D lies on BC, and AD meets BE at P. Triangle ABP has area 54 cm²; triangle APE has area 9 cm². The position of D is otherwise unknown. Find the shaded area of triangle BDP." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">E is the midpoint of side AC of triangle ABC. D lies on BC, and AD meets BE at P. Triangle ABP has area 54 cm²; triangle APE has area 9 cm². The position of D is otherwise unknown. Find the shaded area of triangle BDP.</p>
+      <img class="diagram" src="images/day-11.png" alt="E is the midpoint of side AC of triangle ABC. D lies on BC, and AD meets BE at P. Triangle ABP has area 54 cm²; triangle APE has area 9 cm². The position of D is otherwise unknown. Find the shaded area of triangle BDP." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 12.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html" aria-current="page">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html" aria-current="page">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-12.html
+++ b/apps/geomake/day-12.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 12</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="12" data-help="data/7472b5f5c599085e/day-12" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="12" data-total="14" data-help="data/7472b5f5c599085e/day-12" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-11.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html" rel="prev">← Previous</a>
       <h1>Puzzle 12</h1>
-      <a href="day-13.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">Triangle ABC has area 588 cm². D lies on BC with BD:DC = 3:1, E is the midpoint of AC, and AD meets BE at P. Two segments parallel to BC run across the triangle, one through E and one through P. Find the shaded area of the strip between them.</p>
-    <img class="diagram" src="images/day-12.png" alt="Triangle ABC has area 588 cm². D lies on BC with BD:DC = 3:1, E is the midpoint of AC, and AD meets BE at P. Two segments parallel to BC run across the triangle, one through E and one through P. Find the shaded area of the strip between them." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">Triangle ABC has area 588 cm². D lies on BC with BD:DC = 3:1, E is the midpoint of AC, and AD meets BE at P. Two segments parallel to BC run across the triangle, one through E and one through P. Find the shaded area of the strip between them.</p>
+      <img class="diagram" src="images/day-12.png" alt="Triangle ABC has area 588 cm². D lies on BC with BD:DC = 3:1, E is the midpoint of AC, and AD meets BE at P. Two segments parallel to BC run across the triangle, one through E and one through P. Find the shaded area of the strip between them." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 13.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html" aria-current="page">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html" aria-current="page">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-12.html
+++ b/apps/geomake/day-12.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 12</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-13.html
+++ b/apps/geomake/day-13.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 13</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-13.html
+++ b/apps/geomake/day-13.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 13</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="13" data-help="data/7472b5f5c599085e/day-13" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="13" data-total="14" data-help="data/7472b5f5c599085e/day-13" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-12.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html" rel="prev">← Previous</a>
       <h1>Puzzle 13</h1>
-      <a href="day-14.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">Triangle ABC has area 104 cm². D, E and F lie on BC, CA and AB, respectively, with BD:DC = CE:EA = AF:FB = 3:1. Draw AD, BE and CF. P is the intersection of AD and BE, Q of BE and CF, and R of CF and AD. Find the shaded area of triangle PQR.</p>
-    <img class="diagram" src="images/day-13.png" alt="Triangle ABC has area 104 cm². D, E and F lie on BC, CA and AB, respectively, with BD:DC = CE:EA = AF:FB = 3:1. Draw AD, BE and CF. P is the intersection of AD and BE, Q of BE and CF, and R of CF and AD. Find the shaded area of triangle PQR." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">Triangle ABC has area 104 cm². D, E and F lie on BC, CA and AB, respectively, with BD:DC = CE:EA = AF:FB = 3:1. Draw AD, BE and CF. P is the intersection of AD and BE, Q of BE and CF, and R of CF and AD. Find the shaded area of triangle PQR.</p>
+      <img class="diagram" src="images/day-13.png" alt="Triangle ABC has area 104 cm². D, E and F lie on BC, CA and AB, respectively, with BD:DC = CE:EA = AF:FB = 3:1. Draw AD, BE and CF. P is the intersection of AD and BE, Q of BE and CF, and R of CF and AD. Find the shaded area of triangle PQR." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 14.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html" aria-current="page">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html" aria-current="page">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/day-14.html
+++ b/apps/geomake/day-14.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 14</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/day-14.html
+++ b/apps/geomake/day-14.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 14</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="14" data-help="data/7472b5f5c599085e/day-14" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="14" data-total="14" data-help="data/7472b5f5c599085e/day-14" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
-      <a href="day-13.html" rel="prev">← Previous</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html" rel="prev">← Previous</a>
       <h1>Puzzle 14</h1>
       <span></span>
     </nav>
-    <p class="difficulty">Estimated difficulty: Hard</p>
-    <p id="question">Triangle ABC has area 252 cm². D, E and F lie on BC, CA and AB, respectively. This time BD:DC = 3:1, CE:EA = 1:1 and AF:FB = 2:1. P is the intersection of AD and BE, Q of BE and CF, and R of CF and AD. Find the shaded area of triangle PQR.</p>
-    <img class="diagram" src="images/day-14.png" alt="Triangle ABC has area 252 cm². D, E and F lie on BC, CA and AB, respectively. This time BD:DC = 3:1, CE:EA = 1:1 and AF:FB = 2:1. P is the intersection of AD and BE, Q of BE and CF, and R of CF and AD. Find the shaded area of triangle PQR." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status">Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle" hidden>
+      <p class="difficulty">Estimated difficulty: Hard</p>
+      <p id="question">Triangle ABC has area 252 cm². D, E and F lie on BC, CA and AB, respectively. This time BD:DC = 3:1, CE:EA = 1:1 and AF:FB = 2:1. P is the intersection of AD and BE, Q of BE and CF, and R of CF and AD. Find the shaded area of triangle PQR.</p>
+      <img class="diagram" src="images/day-14.png" alt="Triangle ABC has area 252 cm². D, E and F lie on BC, CA and AB, respectively. This time BD:DC = 3:1, CE:EA = 1:1 and AF:FB = 2:1. P is the intersection of AD and BE, Q of BE and CF, and R of CF and AD. Find the shaded area of triangle PQR." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Solve this puzzle to complete the set.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html" aria-current="page">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html" aria-current="page">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/index.html
+++ b/apps/geomake/index.html
@@ -5,41 +5,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 1</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=9d30678079ce">
+  <link rel="stylesheet" href="styles.css?v=537314553dbd">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=9d30678079ce"></script>
+  <script type="module" src="app.js?v=537314553dbd"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
-  <main data-edition="7472b5f5c599085e" data-day="1" data-help="data/7472b5f5c599085e/day-01" data-hints="3">
+  <main data-edition="7472b5f5c599085e" data-day="1" data-total="14" data-help="data/7472b5f5c599085e/day-01" data-hints="3">
     <nav class="puzzle-nav" aria-label="Puzzles">
       <span></span>
       <h1>Puzzle 1</h1>
-      <a href="day-02.html" rel="next">Next →</a>
+      <a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html" rel="next">Next →</a>
     </nav>
-    <p class="difficulty">Estimated difficulty: Medium</p>
-    <p id="question">The rectangle has area 80 cm². The shaded triangle uses the whole bottom side as its base, and its third vertex lies on the top side. Find the shaded area.</p>
-    <img class="diagram" src="images/day-01.png" alt="The rectangle has area 80 cm². The shaded triangle uses the whole bottom side as its base, and its third vertex lies on the top side. Find the shaded area." width="676" height="676">
-    <form id="answer-form">
-      <label for="answer">Answer <span class="unit">(cm²)</span></label>
-      <div class="answer-row">
-        <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
-        <button id="check" type="submit">Check</button>
+    <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
+    <section id="puzzle" aria-label="Puzzle">
+      <p class="difficulty">Estimated difficulty: Medium</p>
+      <p id="question">The rectangle has area 80 cm². The shaded triangle uses the whole bottom side as its base, and its third vertex lies on the top side. Find the shaded area.</p>
+      <img class="diagram" src="images/day-01.png" alt="The rectangle has area 80 cm². The shaded triangle uses the whole bottom side as its base, and its third vertex lies on the top side. Find the shaded area." width="676" height="676">
+      <form id="answer-form">
+        <label for="answer">Answer <span class="unit">(cm²)</span></label>
+        <div class="answer-row">
+          <input id="answer" name="answer" type="text" maxlength="160" autocomplete="off" spellcheck="false" aria-describedby="answer-format">
+          <button id="check" type="submit">Check</button>
+        </div>
+        <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
+      </form>
+      <p id="feedback" role="status" hidden></p>
+      <p id="progress" class="progress-note">Enter the correct answer to unlock Puzzle 2.</p>
+      <div class="help-actions">
+        <button id="hint" class="text-button" type="button">Hint</button>
+        <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
       </div>
-      <small id="answer-format">Use π, fractions, or sqrt(2). Decimals to two places are fine.</small>
-    </form>
-    <p id="feedback" role="status" hidden></p>
-    <div class="help-actions">
-      <button id="hint" class="text-button" type="button">Hint</button>
-      <button id="explain" class="text-button" type="button" aria-expanded="false" aria-controls="solution">Solution</button>
-    </div>
-    <ol id="hints" aria-live="polite" hidden></ol>
-    <section id="solution" aria-label="Solution" hidden></section>
+      <ol id="hints" aria-live="polite" hidden></ol>
+      <section id="solution" aria-label="Solution" hidden></section>
+    </section>
     <details class="puzzle-list">
       <summary>All puzzles</summary>
-      <ol><li><a href="index.html" aria-current="page">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span></li><li><a href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span></li><li><a href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span></li></ol>
+      <ol><li><a href="index.html" data-puzzle-day="1" data-href="index.html" aria-current="page">Puzzle 1</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="1"></span></li><li><a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html">Puzzle 2</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="2"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html">Puzzle 3</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="3"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html">Puzzle 4</a> <span class="archive-difficulty">· Medium (estimated)</span><span class="puzzle-state" data-state-day="4"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html">Puzzle 5</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="5"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html">Puzzle 6</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="6"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html">Puzzle 7</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="7"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html">Puzzle 8</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="8"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html">Puzzle 9</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="9"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html">Puzzle 10</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="10"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html">Puzzle 11</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="11"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html">Puzzle 12</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="12"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html">Puzzle 13</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="13"> · Locked</span></li><li><a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html">Puzzle 14</a> <span class="archive-difficulty">· Hard (estimated)</span><span class="puzzle-state" data-state-day="14"> · Locked</span></li></ol>
     </details>
-    <noscript><p>Enable JavaScript to check answers or reveal hints.</p></noscript>
+    <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>
 </html>

--- a/apps/geomake/index.html
+++ b/apps/geomake/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 1</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=537314553dbd">
+  <link rel="stylesheet" href="styles.css?v=9f8e67d17ccf">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=537314553dbd"></script>
+  <script type="module" src="app.js?v=9f8e67d17ccf"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>

--- a/apps/geomake/progress.js
+++ b/apps/geomake/progress.js
@@ -1,0 +1,36 @@
+/** Edition-scoped attempts and completion, with tab storage as a fallback. */
+export function createProgress(edition, total, stores = [() => localStorage, () => sessionStorage]) {
+  const key = (day, field) => `geomake:${edition}:${day}:${field}`;
+  const validDay = day => Number.isInteger(day) && day >= 1 && day <= total;
+
+  function values(day, field) {
+    return stores.map(store => {
+      try { return store().getItem(key(day, field)); } catch { return null; }
+    });
+  }
+
+  function save(day, field, value) {
+    let saved = false;
+    for (const store of stores) {
+      try { store().setItem(key(day, field), value); saved = true; } catch { /* Try the other store. */ }
+    }
+    return saved;
+  }
+
+  function completedThrough() {
+    let day = 1;
+    while (day <= total && values(day, 'solved').includes('true')) day++;
+    return day - 1;
+  }
+
+  return {
+    loadAnswer: day => values(day, 'answer').find(value => value !== null) || '',
+    saveAnswer: (day, input) => save(day, 'answer', input),
+    completedThrough,
+    markSolved(day) {
+      const completed = completedThrough();
+      if (!validDay(day) || day > completed + 1) return false;
+      return day <= completed || save(day, 'solved', 'true');
+    },
+  };
+}

--- a/apps/geomake/styles.css
+++ b/apps/geomake/styles.css
@@ -9,6 +9,7 @@ main {
   grid-template-columns: 1fr auto 1fr;
   align-items: baseline;
   gap: 1rem;
+  margin-bottom: 2rem;
 }
 
 .puzzle-nav h1 { margin: 0; font-size: 1rem; }
@@ -50,6 +51,8 @@ input {
 }
 button { cursor: pointer; }
 #check {
+  flex-shrink: 0;
+  white-space: nowrap;
   border: 1px solid var(--text-lighter);
   border-radius: 0;
   background: var(--bg-color);

--- a/apps/geomake/styles.css
+++ b/apps/geomake/styles.css
@@ -17,6 +17,8 @@ main {
 a:hover, .text-button:hover { text-decoration: underline; }
 .difficulty { color: var(--text-muted); font-size: 0.8rem; margin: -1rem 0 1rem; }
 .archive-difficulty { color: var(--text-muted); }
+.progress-note, .puzzle-state { color: var(--text-muted); font-size: 0.8rem; }
+a[aria-disabled="true"] { color: var(--text-muted); cursor: default; text-decoration: none; }
 
 .diagram {
   width: 100%;

--- a/tests/browser_check.py
+++ b/tests/browser_check.py
@@ -252,14 +252,30 @@ def main():
 
             ctx = context()
             page = page_in(ctx)
+            visit(page, '/geomake/day-14.html')
+            expect(page.locator('#puzzle')).to_be_hidden()
+            expect(page.locator('#resume')).to_have_text('Puzzle 1')
+            expect(page.locator('#resume')).to_have_attribute('href', 'index.html')
             for day in range(1, 15):
                 path = '/geomake/' if day == 1 else f'/geomake/day-{day:02}.html'
                 visit(page, path)
+                expect(page.locator('#puzzle')).to_be_visible()
+                if day < 14:
+                    expect(page.locator('[rel="next"]')).to_be_disabled()
+                    assert page.locator(f'.puzzle-list [data-puzzle-day="{day + 1}"]').get_attribute('href') is None
                 directory = ROOT / 'apps/geomake' / page.locator('main').get_attribute('data-help')
                 expected_answer = json.loads((directory / 'check.json').read_text())
+                if day == 1:
+                    page.locator('#answer').fill('0')
+                    page.locator('#check').click()
+                    expect(page.locator('#feedback')).to_have_text('Not quite. Try again.')
+                    expect(page.locator('[rel="next"]')).to_be_disabled()
                 page.locator('#answer').fill(str(expected_answer))
                 page.locator('#check').click()
                 expect(page.locator('#feedback')).to_have_text('Correct.')
+                if day < 14:
+                    expect(page.locator('[rel="next"]')).to_have_attribute('href', f'day-{day + 1:02}.html')
+                    expect(page.locator(f'.puzzle-list [data-puzzle-day="{day + 1}"]')).to_have_attribute('href', f'day-{day + 1:02}.html')
                 for _ in range(3):
                     page.locator('#hint').click()
                     expect(page.locator('#hints li')).to_have_count(_ + 1)
@@ -271,7 +287,11 @@ def main():
                 expect(page.locator('#solution')).to_be_hidden()
                 page.reload()
                 expect(page.locator('#answer')).to_have_value(str(expected_answer))
-            report['flows'].append('Geomake: all fourteen answers, hints, solutions, and persisted input')
+                expect(page.locator('#puzzle')).to_be_visible()
+                if day < 14:
+                    expect(page.locator('[rel="next"]')).to_be_enabled()
+            expect(page.locator('#progress')).to_have_text('All 14 puzzles solved.')
+            report['flows'].append('Geomake: sequential gates, locked direct URLs, wrong answers, all fourteen answers, hints, solutions, and persisted completion')
             ctx.close()
 
             # Lily is an unchanged imported release; smoke-test both bundled languages.


### PR DESCRIPTION
Correct checked answers now unlock the next geometry puzzle at /geomake/. Next, archive navigation, and direct puzzle URLs follow consecutive completion saved per browser; hints and solutions remain available.

Also keeps the Check label on one line and gives puzzle navigation explicit spacing under the host stylesheet.

Imports the reader from [geomake commit 96b51e4](https://github.com/emilesilvis/geomake/commit/96b51e4c79fc7682a67fed79807a4e240632b75f). The fourteen-puzzle edition, published diagrams, current and older help data, shared theme, and Projects navigation are preserved. Browser checks now assert locked direct URLs, incorrect answers, sequential unlocks, and completion across reloads.

Validation: all 41 website generator tests, the website build, and generated-site checks passed locally. Upstream passed 9 JavaScript tests, 5 export tests, and a complete fourteen-puzzle browser walkthrough. The Site checks workflow runs the complete browser and accessibility suite before deployment.
