### PR TITLE
Restore Geomake progress with private recovery codes

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -2,7 +2,7 @@ These are checked-in static applications copied into the site by `build.py`.
 
 | App | Version retained here | Upstream provenance |
 | --- | --- | --- |
-| Geomake | Edition `618a980d4497d066`, twenty-one puzzles with a public progress leaderboard | [emilesilvis/geomake](https://github.com/emilesilvis/geomake), commit `17c6204fcbc1396262679b17546b5c01e30c0fdf`, seed 7. Answers are checked by its Cloudflare Worker; static answer and solution files have been removed. |
+| Geomake | Edition `618a980d4497d066`, twenty-one puzzles with a public progress leaderboard and private recovery codes | [emilesilvis/geomake](https://github.com/emilesilvis/geomake), commit `73a1d70ed3fad2106cf0ffcc88351892a0639777`, seed 7. Answers are checked by its Cloudflare Worker; static answer and solution files have been removed. |
 | How to design a Zachlike | 1.1.0, dated 2026-08-08 | Authored HTML is maintained here; no upstream repository or export command was recorded. |
 | Lily | English/Dutch static release, thirty gardens | Private Lily source, commit `1d3d394652b194c02841bfb703eff95343a17641`; archive checksum and repeatable build instructions are in [README.md](../README.md#lily). |
 
@@ -29,7 +29,9 @@ or the unused `theme.js`. The normal site build adds metadata and versions asset
 
 The first fourteen questions are unchanged. Their published browser progress can
 be recovered after saved answers pass the server checks. Names and solved counts
-are public; a private browser token retains access to each player's saved progress.
+are public; a private recovery code restores access to each player's saved progress across browsers.
+Login controls are below the puzzle lists and hidden while logged in; recovery codes
+and logout remain available at the bottom.
 The leaderboard uses solved count, with equal ranks for ties, and no speed score.
 
 `how-to-design-a-zachlike/index.html` is the canonical guide. `guide.html` is a

--- a/apps/geomake/app.js
+++ b/apps/geomake/app.js
@@ -1,11 +1,13 @@
-import { evaluateAnswer, matchesAnswer } from './answer.js?v=77c516314689';
-import { createProgress } from './progress.js?v=77c516314689';
-import { createLeaderboard } from './leaderboard.js?v=77c516314689';
+import { evaluateAnswer, matchesAnswer } from './answer.js?v=2edb0ab6765d';
+import { createProgress } from './progress.js?v=2edb0ab6765d';
+import { createLeaderboard } from './leaderboard.js?v=2edb0ab6765d';
 
 const page = document.querySelector('main');
 const day = Number(page.dataset.day);
 const total = Number(page.dataset.total);
-const progress = createProgress(page.dataset.edition, total, undefined, JSON.parse(page.dataset.previousEditions || '[]'));
+const previousEditions = JSON.parse(page.dataset.previousEditions || '[]');
+const legacyProgress = createProgress(page.dataset.edition, total, undefined, previousEditions);
+let progress = legacyProgress;
 const publicProgress = page.dataset.api ? createLeaderboard(page.dataset.api, page.dataset.edition) : null;
 const puzzle = document.querySelector('#puzzle');
 const locked = document.querySelector('#locked');
@@ -21,6 +23,12 @@ const playerName = document.querySelector('#player-name');
 const savePlayer = document.querySelector('#save-player');
 const playerSummary = document.querySelector('#player-summary');
 const playerStatus = document.querySelector('#player-status');
+const playerActions = document.querySelector('#player-actions');
+const recoveryDetails = document.querySelector('#recovery-details');
+const recoveryCode = document.querySelector('#recovery-code');
+const recoveryLogin = document.querySelector('#recovery-login');
+const recoveryInput = document.querySelector('#recovery-input');
+const restoreButton = document.querySelector('#restore-player');
 const board = document.querySelector('#leaderboard');
 const boardStatus = document.querySelector('#leaderboard-status');
 let player = null;
@@ -28,6 +36,19 @@ let editingName = false;
 let loadingBoard = false;
 let hintCount = 0;
 let checking = false;
+
+function selectPlayer(next) {
+  const changed = next?.id !== player?.id;
+  player = next;
+  progress = player ? createProgress(page.dataset.edition, total, undefined, previousEditions, player.id) : legacyProgress;
+  if (changed) {
+    answer.value = player ? progress.loadAnswer(day) : '';
+    feedback.hidden = true;
+    recoveryDetails.open = false;
+    recoveryCode.textContent = '';
+    document.querySelector('#copy-status').hidden = true;
+  }
+}
 
 function updateProgress() {
   const completed = publicProgress ? player?.completedThrough || 0 : progress.completedThrough();
@@ -37,6 +58,9 @@ function updateProgress() {
   if (publicProgress) {
     playerForm.hidden = !!player && !editingName;
     playerSummary.hidden = !player;
+    playerActions.hidden = !player;
+    recoveryDetails.hidden = !player;
+    recoveryLogin.hidden = !!player;
     if (player) document.querySelector('#player-label').textContent = `${player.name} · ${player.solved.length} of ${total} solved`;
   }
   for (const link of puzzleLinks) {
@@ -69,7 +93,7 @@ window.addEventListener('storage', event => {
 });
 window.addEventListener('pageshow', () => publicProgress ? restorePlayer() : updateProgress());
 
-answer.value = progress.loadAnswer(day);
+answer.value = publicProgress ? '' : progress.loadAnswer(day);
 answer.addEventListener('input', () => {
   feedback.hidden = true;
   progress.saveAnswer(day, answer.value);
@@ -88,7 +112,7 @@ async function readHelp(file) {
 
 document.querySelector('#answer-form').addEventListener('submit', async event => {
   event.preventDefault();
-  if (checking || puzzle.hidden) return;
+  if (checking || restoringPlayer || puzzle.hidden) return;
   const submitted = answer.value;
   checking = true;
   document.querySelector('#check').disabled = true;
@@ -97,7 +121,6 @@ document.querySelector('#answer-form').addEventListener('submit', async event =>
     if (publicProgress) {
       const result = await publicProgress.check(day, submitted);
       player = result.player;
-      if (result.correct) progress.markSolved(day);
       updateProgress();
       if (answer.value === submitted) message(result.correct ? 'Correct.' : 'Not quite. Try again.');
       if (result.correct && board.open) await refreshBoard();
@@ -129,16 +152,17 @@ function playerMessage(text) {
 async function syncPreviousAnswers() {
   // Existing browser completion is only credited publicly after each saved
   // answer has passed the same server check as a new solve.
-  const completed = progress.completedThrough();
+  const completed = legacyProgress.completedThrough();
   while (player.completedThrough < completed) {
     const next = player.completedThrough + 1;
-    const saved = progress.loadAnswer(next);
+    const saved = legacyProgress.loadAnswer(next);
     if (!saved) break;
     let result;
     try { result = await publicProgress.check(next, saved); }
     catch (error) { if (error.status === 400) break; throw error; }
     player = result.player;
     if (!result.correct) break;
+    progress.saveAnswer(next, saved);
   }
 }
 
@@ -147,11 +171,11 @@ async function restorePlayer() {
   if (!publicProgress || restoringPlayer || savePlayer.disabled) return;
   restoringPlayer = true;
   savePlayer.disabled = true;
+  restoreButton.disabled = true;
   playerMessage('Loading your progress…');
   try {
-    player = await publicProgress.loadPlayer();
+    selectPlayer(await publicProgress.loadPlayer());
     if (player) {
-      await syncPreviousAnswers();
       if (!editingName) playerName.value = player.name;
     }
     playerMessage('');
@@ -159,6 +183,7 @@ async function restorePlayer() {
     playerMessage(error instanceof Error ? error.message : 'Could not load your progress. Please try again.');
   } finally {
     savePlayer.disabled = false;
+    restoreButton.disabled = false;
     restoringPlayer = false;
     updateProgress();
   }
@@ -167,28 +192,93 @@ async function restorePlayer() {
 playerForm.addEventListener('submit', async event => {
   event.preventDefault();
   if (!publicProgress || savePlayer.disabled) return;
+  const registering = !player;
   savePlayer.disabled = true;
+  restoreButton.disabled = true;
   playerMessage('Saving…');
   try {
-    player = await publicProgress.savePlayer(playerName.value);
-    await syncPreviousAnswers();
+    selectPlayer(await publicProgress.savePlayer(playerName.value));
+    // Import pre-leaderboard completion only when first registering. A recovery
+    // login must never submit a different player's cached answers.
+    if (registering) await syncPreviousAnswers();
     editingName = false;
     playerName.value = player.name;
     playerMessage('');
+    if (registering) recoveryDetails.open = true;
     updateProgress();
     if (board.open) await refreshBoard();
   } catch (error) {
     playerMessage(error instanceof Error ? error.message : 'Could not save your name. Please try again.');
   } finally {
     savePlayer.disabled = false;
+    restoreButton.disabled = false;
     updateProgress();
   }
+});
+
+document.querySelector('#recovery-form').addEventListener('submit', async event => {
+  event.preventDefault();
+  if (!publicProgress || restoringPlayer || savePlayer.disabled || checking) return;
+  restoringPlayer = true;
+  savePlayer.disabled = true;
+  restoreButton.disabled = true;
+  document.querySelector('#check').disabled = true;
+  playerMessage('Loading your saved progress…');
+  try {
+    selectPlayer(await publicProgress.restorePlayer(recoveryInput.value));
+    editingName = false;
+    playerName.value = player.name;
+    recoveryInput.value = '';
+    recoveryLogin.open = false;
+    playerMessage('Logged in. Your saved progress is restored.');
+    updateProgress();
+    if (board.open) await refreshBoard();
+  } catch (error) {
+    playerMessage(error instanceof Error ? error.message : 'Could not restore your progress. Please try again.');
+  } finally {
+    restoringPlayer = false;
+    savePlayer.disabled = false;
+    restoreButton.disabled = false;
+    document.querySelector('#check').disabled = false;
+    updateProgress();
+  }
+});
+
+recoveryDetails.addEventListener('toggle', () => {
+  recoveryCode.textContent = recoveryDetails.open && player ? publicProgress.recoveryCode() : '';
+});
+
+document.querySelector('#copy-recovery-code').addEventListener('click', async () => {
+  if (!player) return;
+  const status = document.querySelector('#copy-status');
+  try {
+    await navigator.clipboard.writeText(publicProgress.recoveryCode());
+    status.textContent = 'Copied. Save it somewhere private.';
+  } catch {
+    status.textContent = 'Select and copy the code above.';
+  }
+  status.hidden = false;
 });
 
 document.querySelector('#change-name').addEventListener('click', () => {
   editingName = true;
   updateProgress();
   playerName.focus();
+});
+
+document.querySelector('#log-out').addEventListener('click', async () => {
+  if (!publicProgress || restoringPlayer || checking || savePlayer.disabled) return;
+  try {
+    publicProgress.logOut();
+    selectPlayer(null);
+    editingName = false;
+    playerName.value = '';
+    playerMessage('Logged out. Use your recovery code to log back in.');
+    updateProgress();
+    if (board.open) await refreshBoard();
+  } catch (error) {
+    playerMessage(error instanceof Error ? error.message : 'Could not log out. Please try again.');
+  }
 });
 
 async function refreshBoard() {

--- a/apps/geomake/day-02.html
+++ b/apps/geomake/day-02.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 2</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 2</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="3" data-href="day-03.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Medium</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-03.html
+++ b/apps/geomake/day-03.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 3</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 3</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="4" data-href="day-04.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-04.html
+++ b/apps/geomake/day-04.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 4</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 4</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="5" data-href="day-05.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Medium</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-05.html
+++ b/apps/geomake/day-05.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 5</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 5</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="6" data-href="day-06.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-06.html
+++ b/apps/geomake/day-06.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 6</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 6</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="7" data-href="day-07.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-07.html
+++ b/apps/geomake/day-07.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 7</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 7</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="8" data-href="day-08.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-08.html
+++ b/apps/geomake/day-08.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 8</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 8</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="9" data-href="day-09.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-09.html
+++ b/apps/geomake/day-09.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 9</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 9</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="10" data-href="day-10.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-10.html
+++ b/apps/geomake/day-10.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 10</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 10</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="11" data-href="day-11.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-11.html
+++ b/apps/geomake/day-11.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 11</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 11</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="12" data-href="day-12.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-12.html
+++ b/apps/geomake/day-12.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 12</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 12</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="13" data-href="day-13.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-13.html
+++ b/apps/geomake/day-13.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 13</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 13</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="14" data-href="day-14.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-14.html
+++ b/apps/geomake/day-14.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 14</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 14</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="15" data-href="day-15.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-15.html
+++ b/apps/geomake/day-15.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 15</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 15</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="16" data-href="day-16.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-16.html
+++ b/apps/geomake/day-16.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 16</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 16</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="17" data-href="day-17.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-17.html
+++ b/apps/geomake/day-17.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 17</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 17</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="18" data-href="day-18.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-18.html
+++ b/apps/geomake/day-18.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 18</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 18</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="19" data-href="day-19.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-19.html
+++ b/apps/geomake/day-19.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 19</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 19</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="20" data-href="day-20.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-20.html
+++ b/apps/geomake/day-20.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 20</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 20</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="21" data-href="day-21.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/day-21.html
+++ b/apps/geomake/day-21.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 21</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 21</h1>
       <span></span>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Hard</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/index.html
+++ b/apps/geomake/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Puzzle 1</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="styles.css?v=77c516314689">
+  <link rel="stylesheet" href="styles.css?v=2edb0ab6765d">
   <script src="/static/js/theme.js"></script>
-  <script type="module" src="app.js?v=77c516314689"></script>
+  <script type="module" src="app.js?v=2edb0ab6765d"></script>
 </head>
 <body>
   <nav class="app-nav" aria-label="Site"><a class="back-link" href="/projects.html">← Projects</a><button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode"><span id="theme-icon" aria-hidden="true">🌙</span></button></nav>
@@ -17,18 +17,7 @@
       <h1>Puzzle 1</h1>
       <a role="link" aria-disabled="true" data-puzzle-day="2" data-href="day-02.html" rel="next">Next →</a>
     </nav>
-    <section id="player" aria-label="Your progress">
-      <form id="player-form">
-        <label for="player-name">Name on leaderboard</label>
-        <div class="answer-row">
-          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
-          <button id="save-player" type="submit">Save name</button>
-        </div>
-        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
-      </form>
-      <p id="player-summary" hidden><span id="player-label"></span> · <button id="change-name" class="text-button" type="button">Change name</button></p>
-      <p id="player-status" role="status" hidden></p>
-    </section>
+    <p id="player-summary" hidden><span id="player-label"></span></p>
     <p id="locked" role="status" hidden>Solve <a id="resume" href="index.html">Puzzle 1</a> to unlock this puzzle.</p>
     <section id="puzzle" aria-label="Puzzle" hidden>
       <p class="difficulty">Estimated difficulty: Medium</p>
@@ -62,6 +51,39 @@
       </table>
       <button id="refresh-leaderboard" class="text-button" type="button">Refresh</button>
     </details>
+    <section id="player" aria-label="Your progress">
+      <form id="player-form">
+        <label for="player-name">Name on leaderboard</label>
+        <div class="answer-row">
+          <input id="player-name" name="nickname" type="text" maxlength="40" required autocomplete="nickname" aria-describedby="public-name-note">
+          <button id="save-player" type="submit">Save name</button>
+        </div>
+        <small id="public-name-note">Your name and number of solved puzzles will be public. A nickname is fine.</small>
+        <small>Already played? Use your recovery code below to get your progress back.</small>
+      </form>
+      <div id="player-actions" hidden>
+        <button id="change-name" class="text-button" type="button">Change name</button>
+        <button id="log-out" class="text-button" type="button">Log out</button>
+      </div>
+      <details id="recovery-details" class="recovery" hidden>
+        <summary>Your recovery code</summary>
+        <p>Your progress is saved online. Save this code somewhere private to log back in or use another device. Anyone with it can access your progress.</p>
+        <code id="recovery-code"></code>
+        <button id="copy-recovery-code" class="text-button" type="button">Copy code</button>
+        <p id="copy-status" role="status" hidden></p>
+      </details>
+      <details id="recovery-login" class="recovery">
+        <summary>Log in with a recovery code</summary>
+        <form id="recovery-form">
+          <label for="recovery-input">Private recovery code</label>
+          <div class="answer-row">
+            <input id="recovery-input" name="recovery-code" type="password" maxlength="100" required autocomplete="off" autocapitalize="none" spellcheck="false">
+            <button id="restore-player" type="submit">Log in</button>
+          </div>
+        </form>
+      </details>
+      <p id="player-status" role="status" hidden></p>
+    </section>
     <noscript><p>Enable JavaScript to check answers, reveal hints, and unlock puzzles.</p></noscript>
   </main>
 </body>

--- a/apps/geomake/leaderboard.js
+++ b/apps/geomake/leaderboard.js
@@ -12,19 +12,31 @@ export function createLeaderboard(api, edition, stores = [() => localStorage, ()
     const existing = token();
     if (existing) return existing;
     const created = Array.from(crypto.getRandomValues(new Uint8Array(32)), byte => byte.toString(16).padStart(2, '0')).join('');
-    let saved = false;
-    for (const store of stores) {
-      try { store().setItem(key, created); saved = true; } catch { /* Try tab storage. */ }
-    }
-    if (!saved) throw new Error('Allow browser storage to save your name and progress.');
+    saveToken(created);
     return created;
   }
-  async function request(path, data, authenticated = true) {
+  function saveToken(value) {
+    const previous = stores.map(store => {
+      try { return store().getItem(key); } catch { return null; }
+    });
+    for (const store of stores) {
+      try { store().setItem(key, value); } catch { /* Try tab storage. */ }
+    }
+    if (token() === value) return;
+    // A readable but unwritable older store must not silently win on reload.
+    stores.forEach((store, i) => {
+      try {
+        if (previous[i] === null) store().removeItem(key);
+        else store().setItem(key, previous[i]);
+      } catch { /* A failed store remains unchanged. */ }
+    });
+    throw new Error('Allow browser storage to save your name and progress.');
+  }
+  async function request(path, data, authenticated = true, credential = token()) {
     const headers = {};
     if (authenticated) {
-      const saved = token();
-      if (!saved) throw new Error('Enter your name to save progress.');
-      headers.Authorization = `Bearer ${saved}`;
+      if (!credential) throw new Error('Enter your name or log in with a recovery code.');
+      headers.Authorization = `Bearer ${credential}`;
     }
     if (data !== undefined) headers['Content-Type'] = 'application/json';
     const response = await send(`${api}${path}?edition=${encodeURIComponent(edition)}`, {
@@ -46,6 +58,25 @@ export function createLeaderboard(api, edition, stores = [() => localStorage, ()
       catch (error) { if (error.status === 401) return null; throw error; }
     },
     savePlayer(name) { ensureToken(); return request('/player', { name }); },
+    logOut() {
+      for (const store of stores) {
+        try { store().removeItem(key); } catch { /* Try the other store. */ }
+      }
+      if (token()) throw new Error('Allow browser storage to log out.');
+    },
+    recoveryCode: () => token()?.match(/.{8}/g).join('-') || '',
+    async restorePlayer(code) {
+      const candidate = typeof code === 'string' ? code.trim().toLowerCase().replace(/[\s-]/g, '') : '';
+      if (!validToken(candidate)) throw new Error('Enter the full private recovery code.');
+      let player;
+      try { player = await request('/player', undefined, true, candidate); }
+      catch (error) {
+        if (error.status === 401) throw new Error('That recovery code was not recognised. Check it and try again.');
+        throw error;
+      }
+      saveToken(candidate);
+      return player;
+    },
     check: (day, answer) => request('/check', { day, answer }),
     loadBoard: () => request('/leaderboard', undefined, false),
   };

--- a/apps/geomake/progress.js
+++ b/apps/geomake/progress.js
@@ -1,11 +1,12 @@
 /** Edition-scoped attempts and completion, with tab storage as a fallback. */
-export function createProgress(edition, total, stores = [() => localStorage, () => sessionStorage], previousEditions = []) {
-  const key = (day, field) => `geomake:${edition}:${day}:${field}`;
+export function createProgress(edition, total, stores = [() => localStorage, () => sessionStorage], previousEditions = [], playerId = '') {
+  const owner = playerId ? `player:${playerId}:` : '';
+  const key = (day, field) => `geomake:${edition}:${owner}${day}:${field}`;
   const validDay = day => Number.isInteger(day) && day >= 1 && day <= total;
 
   function values(day, field) {
     const keys = [key(day, field), ...previousEditions.filter(item => day <= item.total)
-      .map(item => `geomake:${item.edition}:${day}:${field}`)];
+      .map(item => `geomake:${item.edition}:${owner}${day}:${field}`)];
     return keys.flatMap(name => stores.map(store => {
       try { return store().getItem(name); } catch { return null; }
     }));

--- a/apps/geomake/styles.css
+++ b/apps/geomake/styles.css
@@ -50,7 +50,7 @@ input {
   padding: 0.3rem 0.5rem;
 }
 button { cursor: pointer; }
-#check, #save-player {
+#check, #save-player, #restore-player {
   flex-shrink: 0;
   white-space: nowrap;
   border: 1px solid var(--text-lighter);
@@ -69,8 +69,14 @@ button:disabled { cursor: default; opacity: 0.6; }
 .puzzle-list ol { list-style: none; padding: 0; margin: 0.5rem 0; }
 .puzzle-list li { margin: 0.25rem 0; }
 .puzzle-list [aria-current="page"] { color: var(--text-color); font-weight: 600; }
-#player { margin-bottom: 1.5rem; }
+#player { margin-top: 2rem; }
+#player-actions { display: flex; gap: 1rem; margin-bottom: 0.75rem; font-size: 0.8rem; }
 #player-summary { color: var(--text-muted); font-size: 0.8rem; }
+.recovery { margin-top: 0.75rem; font-size: 0.8rem; }
+.recovery summary { color: var(--accent); cursor: pointer; width: fit-content; }
+.recovery p { margin: 0.75rem 0; }
+.recovery form { margin-top: 0.75rem; }
+#recovery-code { display: block; overflow-wrap: anywhere; margin-bottom: 0.75rem; user-select: all; }
 #leaderboard-table { width: 100%; border-collapse: collapse; margin: 0.5rem 0 1rem; }
 #leaderboard-table th, #leaderboard-table td { padding: 0.4rem 0.3rem; text-align: left; border-bottom: 1px solid var(--border-color); }
 #leaderboard-table :is(th, td):last-child { text-align: right; white-space: nowrap; }

--- a/tests/browser_check.py
+++ b/tests/browser_check.py
@@ -367,6 +367,24 @@ def main():
             page.locator('#save-player').click()
             expect(page.locator('#player-label')).to_have_text(f'Changed name · {total} of {total} solved')
             expect(page.locator('#leaderboard-rows')).to_contain_text('Changed name')
+            expect(page.locator('#recovery-login')).to_be_hidden()
+            page.locator('#recovery-details summary').click()
+            expect(page.locator('#recovery-code')).to_have_text(re.compile(r'(?:[a-f0-9]{8}-){7}[a-f0-9]{8}'))
+            code = page.locator('#recovery-code').inner_text()
+            page.locator('#log-out').click()
+            expect(page.locator('#player-form')).to_be_visible()
+            page.locator('#recovery-login summary').click()
+            page.locator('#recovery-input').fill('f' * 64)
+            page.locator('#restore-player').click()
+            expect(page.locator('#player-status')).to_contain_text('not recognised')
+            page.locator('#recovery-input').fill(code.upper())
+            page.locator('#restore-player').click()
+            expect(page.locator('#player-label')).to_have_text(f'Changed name · {total} of {total} solved')
+            expect(page.locator('#recovery-login')).to_be_hidden()
+            page.reload()
+            expect(page.locator('#player-label')).to_have_text(f'Changed name · {total} of {total} solved')
+            expect(page.locator('#answer')).to_have_value(str(total * 10))
+            page.locator('#leaderboard summary').click()
             api_controls['board_error'] = True
             page.locator('#refresh-leaderboard').click()
             expect(page.locator('#leaderboard-status')).to_have_text('Please try again.')
@@ -383,7 +401,7 @@ def main():
                     assert page.evaluate('(async () => (await axe.run(document)).violations)()') == []
                     assert page.evaluate('document.documentElement.scrollWidth <= innerWidth + 1')
                     page.screenshot(path=str(ARTIFACTS / f'geomake-{width}-{theme}.png'))
-            report['flows'].append(f'Geomake: name entry, {total} sequential API checks, wrong answers, hints, no solutions, persisted completion, name changes, leaderboard retry and accessibility')
+            report['flows'].append(f'Geomake: name entry, {total} sequential API checks, wrong answers, hints, no solutions, persisted completion, name changes, recovery code login/logout, invalid recovery, leaderboard retry and accessibility')
             ctx.close()
 
             # Lily is an unchanged imported release; smoke-test both bundled languages.


### PR DESCRIPTION
Import Geomake’s private recovery-code login so players can restore their existing server progress after losing browser storage. Login controls are below the puzzle lists and hidden while logged in; code export, name changes and logout stay at the bottom.

This imports emilesilvis/geomake@73a1d70ed3fad2106cf0ffcc88351892a0639777, preserving the existing edition, puzzle images, shared theme and project navigation. The backend migration and Worker are already deployed, with Emile’s 8 and Greyfox’s 14 solves verified unchanged.

Validation: 41 generator tests, generated-site checks, and 137 browser/viewport/theme checks with 8 interaction groups, including recovery, invalid codes, reload persistence and accessibility.
